### PR TITLE
Remove __actasmsvc__

### DIFF
--- a/libs/compilerAdapters/include/compilerAdapters/compilerFeatures.h
+++ b/libs/compilerAdapters/include/compilerAdapters/compilerFeatures.h
@@ -21,7 +21,7 @@
 
 // Check if compiler supports UUID
 #ifndef COMPILER_SUPPORTS_UUID
-#  if defined(__clang__) || defined(__actasmsvc__) || defined(__GNUC__)
+#  if defined(__clang__) || defined(__GNUC__)
 #    define COMPILER_SUPPORTS_UUID 0
 #  elif defined(_MSC_VER)
 #    define COMPILER_SUPPORTS_UUID 1

--- a/libs/compilerAdapters/include/compilerAdapters/compilerWarnings_impl.h
+++ b/libs/compilerAdapters/include/compilerAdapters/compilerWarnings_impl.h
@@ -7,7 +7,7 @@
 #ifndef LIBLET_COMPILERADAPTERS_COMPILERWARNINGS_IMPL_H
 #define LIBLET_COMPILERADAPTERS_COMPILERWARNINGS_IMPL_H
 
-#if defined(__clang__) || defined(__actasmsvc__)
+#if defined(__clang__)
 
 #define COMPILER_WARNING_PUSH() __pragma(clang diagnostic push)
 #define COMPILER_WARNING_DISABLE_ALL(msvcNum, clangWarn) COMPILER_WARNING_DISABLE_CLANG(clangWarn)

--- a/libs/compilerAdapters/include/compilerAdapters/managedCpp.h
+++ b/libs/compilerAdapters/include/compilerAdapters/managedCpp.h
@@ -14,16 +14,16 @@
 	The pragmas below allow explicitly indicate that code is unmanaged, but these
 	pragmas are not recognized by Clang compiler.
  */
-#if !defined(__clang__) && !defined(__actasmsvc__)
+#if !defined(__clang__)
 
 #define MSO_PRAGMA_MANAGED_PUSH_OFF __pragma(managed(push, off))
 #define MSO_PRAGMA_MANAGED_POP      __pragma(managed(pop))
 
-#else // !defined(__clang__) && !defined(__actasmsvc__)
+#else // !defined(__clang__)
 
 #define MSO_PRAGMA_MANAGED_PUSH_OFF
 #define MSO_PRAGMA_MANAGED_POP
 
-#endif // !defined(__clang__) && !defined(__actasmsvc__)
+#endif // !defined(__clang__)
 
 #endif // COMPILERADAPTERS_MANAGEDCPP_H

--- a/libs/debugAssertApi/include/debugAssertApi/debugAssertDetails.h
+++ b/libs/debugAssertApi/include/debugAssertApi/debugAssertDetails.h
@@ -59,7 +59,7 @@ __pragma(warning(suppress:4472)) enum class AssertResult : uint32_t
 #endif // C++
 
 // TODO: move this abstraction into compilerAdapters? Except it depends on windows - hmm
-#if defined(__clang__) || defined(__actasmsvc__) || defined(__cplusplus_cli) || defined(__INTELLISENSE__)
+#if defined(__clang__) || defined(__cplusplus_cli) || defined(__INTELLISENSE__)
 #define AssertBreak(wzMsg) __debugbreak()
 #elif defined(_DBGRAISEASSERTIONFAILURE_)
 #define AssertBreak(wzMsg) \


### PR DESCRIPTION
This is a (dead) internal concept and is not required by external consumers