### PR TITLE
Fix packing/alignment issues in Win32 builds

### DIFF
--- a/libs/object/tests/refCountedObjectTest.cpp
+++ b/libs/object/tests/refCountedObjectTest.cpp
@@ -430,8 +430,7 @@ struct AsyncDeleter
 		try
 		{
 			// Ideally we want to show here how to use dispatch queues, but we cannot add DispatchQueue liblet dependency here.
-			auto x = std::async(std::launch::async, [obj]() noexcept { TObject::RefCountPolicy::template Delete(obj); });
-			x.wait();
+			std::thread([obj]() noexcept { TObject::RefCountPolicy::template Delete(obj); }).detach();
 		}
 		catch (...)
 		{

--- a/libs/object/tests/refCountedObjectTest.cpp
+++ b/libs/object/tests/refCountedObjectTest.cpp
@@ -430,7 +430,8 @@ struct AsyncDeleter
 		try
 		{
 			// Ideally we want to show here how to use dispatch queues, but we cannot add DispatchQueue liblet dependency here.
-			std::async(std::launch::async, [obj]() noexcept { TObject::RefCountPolicy::template Delete(obj); });
+			auto x = std::async(std::launch::async, [obj]() noexcept { TObject::RefCountPolicy::template Delete(obj); });
+			x.wait();
 		}
 		catch (...)
 		{

--- a/libs/object/tests/unknownObjectTest.cpp
+++ b/libs/object/tests/unknownObjectTest.cpp
@@ -608,8 +608,7 @@ struct AsyncDeleter2
 		try
 		{
 			// Ideally we want to show here how to use dispatch queues, but we cannot add DispatchQueue liblet dependency here.
-			auto x = std::async(std::launch::async, [obj]() noexcept { TObject::RefCountPolicy::template Delete(obj); });
-			x.wait();
+			std::thread([obj]() noexcept { TObject::RefCountPolicy::template Delete(obj); }).detach();
 		}
 		catch (...)
 		{

--- a/libs/object/tests/unknownObjectTest.cpp
+++ b/libs/object/tests/unknownObjectTest.cpp
@@ -608,7 +608,8 @@ struct AsyncDeleter2
 		try
 		{
 			// Ideally we want to show here how to use dispatch queues, but we cannot add DispatchQueue liblet dependency here.
-			std::async(std::launch::async, [obj]() noexcept { TObject::RefCountPolicy::template Delete(obj); });
+			auto x = std::async(std::launch::async, [obj]() noexcept { TObject::RefCountPolicy::template Delete(obj); });
+			x.wait();
 		}
 		catch (...)
 		{

--- a/libs/platformAdapters/CMakeLists.txt
+++ b/libs/platformAdapters/CMakeLists.txt
@@ -6,6 +6,7 @@ liblet(platformAdapters
     Mso::compilerAdapters
     Mso::debugAssertApi
     Mso::oacr
-    Mso::platform_posix
     Mso::tagUtils
+  DEPENDS_POSIX
+    Mso::platform_posix
 )


### PR DESCRIPTION
The platformAdapters liblet had a cross-platform dependency on platform_posix, when the dependency should have been limited to posix-only platforms (everything but Windows). 

platform_posix includes empty pshpack8.h and poppack.h headers. On Windows builds, these were being used in place of the real headers, which actually change the packing size. To make things worse, they were mingled with pshpack2.h and pshpack4.h from the WinSDK. All of these packing headers are used by the Windows SDK (windows.h, winnt.h, ...).

This led to an unbalanced series of pragma pack push/pop operations which broke the whole header system.

While I was fixing this issue and verifying it in my own project, I ran into 2 C++17 bugs. std::async changed to [[nodiscard]] in C++17, causing build breaks in two UTs. I added code which effectively matches what you get in a C++14 build.