### PR TITLE
Updated a set of liblets from RNW Mso fork

### DIFF
--- a/change/@microsoft-mso-2020-04-03-11-53-54-MS_UpdateLiblets1.json
+++ b/change/@microsoft-mso-2020-04-03-11-53-54-MS_UpdateLiblets1.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updated a set of liblets from RNW Mso fork",
+  "packageName": "@microsoft/mso",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-03T18:53:54.569Z"
+}

--- a/libs/cppExtensions/CMakeLists.txt
+++ b/libs/cppExtensions/CMakeLists.txt
@@ -4,8 +4,8 @@
 liblet(cppExtensions
   DEPENDS
     Mso::compilerAdapters
-    Mso::cppType
     Mso::platformAdapters
+    Mso::typeTraits
   DEPENDS_POSIX
     Mso::oacr_posix
 )

--- a/libs/cppExtensions/include/cppExtensions/autoRestore.h
+++ b/libs/cppExtensions/include/cppExtensions/autoRestore.h
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+#pragma once
+#ifndef MSO_CPPEXTENSIONS_AUTORESTORE_H
+#define MSO_CPPEXTENSIONS_AUTORESTORE_H
 /**
   Helper classes to automatically restore/cleanup/undo an operation.
 */
-#ifndef _CPPEXTENSIONS_AUTORESTORE_H_
-#define _CPPEXTENSIONS_AUTORESTORE_H_
 
 #include <compilerAdapters/compilerWarnings.h>
 #include <compilerAdapters/cppMacros.h>
@@ -255,4 +256,4 @@ inline TCleanup<Func> Make(const Func& pfnCleanup) noexcept
 
 #endif // __cplusplus
 
-#endif // _CPPEXTENSIONS_AUTORESTORE_H_
+#endif // MSO_CPPEXTENSIONS_AUTORESTORE_H

--- a/libs/crash/include/crash/verifyElseCrash.h
+++ b/libs/crash/include/crash/verifyElseCrash.h
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 #pragma once
-#ifndef _CPPEXTENSIONS_VERIFYELSECRASH_H_
-#define _CPPEXTENSIONS_VERIFYELSECRASH_H_
+#ifndef MSO_CRASH_VERIFYELSECRASH_H
+#define MSO_CRASH_VERIFYELSECRASH_H
 
 #include <compilerAdapters/declspecDefinitions.h>
 #include <debugAssertApi/debugAssertApi.h>
@@ -34,4 +34,4 @@ DECLSPEC_NORETURN void CrashWithRecovery(uint32_t tag) noexcept;
 
 #define CrashWithRecoveryOnOOM() CrashWithRecovery(0)
 
-#endif // _CPPEXTENSIONS_VERIFYELSECRASH_H_
+#endif // MSO_CRASH_VERIFYELSECRASH_H

--- a/libs/crash/src/crash_min.cpp
+++ b/libs/crash/src/crash_min.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-//#include "precomp.h"
-
 #include <crash/verifyElseCrash.h>
 #include <compilerAdapters/cppMacros.h>
 #include <platformAdapters/windowsFirst.h>

--- a/libs/debugAssertApi/include/debugAssertApi/debugAssertApi.h
+++ b/libs/debugAssertApi/include/debugAssertApi/debugAssertApi.h
@@ -1,12 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+#pragma once
+#ifndef MSO_DEBUGASSERTAPI_DEBUGASSERTAPI_H
+#define MSO_DEBUGASSERTAPI_DEBUGASSERTAPI_H
+
 /**
   API for debug asserts. Must support C callers
 */
-#pragma once
-#ifndef LIBLET_DEBUGASSERTAPI_DEBUGASSERTAPI_H
-#define LIBLET_DEBUGASSERTAPI_DEBUGASSERTAPI_H
+
 #ifndef RC_INVOKED
 #pragma pack(push, 8)
 
@@ -273,7 +275,9 @@ private:
   AssertListener m_listener;
 };
 
-using AssertHandler = int32_t (*)(const MsoAssertParams& params, const char* szMsg);
+enum class AssertResult : uint32_t;
+
+using AssertHandler = AssertResult (*)(const MsoAssertParams& params, const char* szMsg);
 
 /**
   Set the assert handler for this process. The previous handler is returned.
@@ -306,4 +310,4 @@ private:
 #pragma pack(pop)
 #endif // RC_INVOKED
 
-#endif // LIBLET_DEBUGASSERTAPI_DEBUGASSERTAPI_H
+#endif // MSO_DEBUGASSERTAPI_DEBUGASSERTAPI_H

--- a/libs/debugAssertApi/include/debugAssertApi/debugAssertDetails.h
+++ b/libs/debugAssertApi/include/debugAssertApi/debugAssertDetails.h
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+#pragma once
+#ifndef MSO_DEBUGASSERTAPI_DEBUGASSERTDETAILS_H
+#define MSO_DEBUGASSERTAPI_DEBUGASSERTDETAILS_H
 /**
   Private implementation details for debug assert macros
   This header should not be included directly - only through debugAssertApi.h
@@ -8,9 +11,7 @@
    Note that C4706 is purposely left enabled. Assignments in inside Assert
   statements are almost always a bug (e.g. Assert(m_foo = fooBar))
 */
-#pragma once
-#ifndef LIBLET_DEBUGASSERTAPI_DEBUGASSERTDETAILS_H
-#define LIBLET_DEBUGASSERTAPI_DEBUGASSERTDETAILS_H
+
 #include <cstdarg>
 #include <cstdint>
 #include <compilerAdapters/compilerWarnings.h>
@@ -248,4 +249,4 @@ static
 #define AssertImpliesTag(a, b, tag) AssertSzTag(FImplies(a, b), #a " => " #b, tag)
 #define AssertBiImpliesTag(a, b, tag) AssertSzTag(FBiImplies(a, b), #a " <==> " #b, tag)
 
-#endif // LIBLET_DEBUGASSERTAPI_DEBUGASSERTDETAILS_H
+#endif // MSO_DEBUGASSERTAPI_DEBUGASSERTDETAILS_H

--- a/libs/guid/tests/CMakeLists.txt
+++ b/libs/guid/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-liblet(typeTraits
-  DEPENDS
-    Mso::compilerAdapters
+liblet_tests(
+  SOURCES
+    guidTest.cpp
 )

--- a/libs/guid/tests/guidTest.cpp
+++ b/libs/guid/tests/guidTest.cpp
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#include "guid/msoGuid.h"
-#include "motifCpp/testCheck.h"
+#include <guid/msoGuid.h>
+#include <motifCpp/testCheck.h>
+#include <compilerAdapters/declspecDefinitions.h>
 
 MSO_STRUCT_GUID(IBaseInterface, "38E23DC7-92B1-4B21-B5FE-6EA786817915")
 struct DECLSPEC_NOVTABLE IBaseInterface
@@ -98,8 +99,9 @@ MSO_DEFINE_GUID_TOKEN(MyProductId2, "AABFD353-B463-41A2-B04C-9A6AB7541D20")
 
 MSO_DEFINE_GUID_TOKEN(FailingToParseId, "A39D5FC8-0641-4EEE-8C97-DDEF114D487D")
 
-TestClassComponent(GuidTest, Mso.Guid)
-    TEST_CLASS (GuidTest){static std::string GuidToString(const GUID& guid){char str[37];
+#if 0
+TEST_CLASS (GuidTest){
+  static std::string GuidToString(const GUID& guid){char str[37];
 sprintf_s(
     str,
     _countof(str),
@@ -183,3 +185,4 @@ TEST_METHOD(TestTypeGuids_DefineGuidToken)
 }
 }
 ;
+#endif

--- a/libs/guid/tests/guidTest.cpp
+++ b/libs/guid/tests/guidTest.cpp
@@ -1,0 +1,185 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "guid/msoGuid.h"
+#include "motifCpp/testCheck.h"
+
+MSO_STRUCT_GUID(IBaseInterface, "38E23DC7-92B1-4B21-B5FE-6EA786817915")
+struct DECLSPEC_NOVTABLE IBaseInterface
+{
+  virtual void BaseMethod() = 0;
+};
+
+MSO_STRUCT_GUID(IDerivedInterface, "9E11BC42-1416-45B1-9712-AA4AAD87F78B")
+struct DECLSPEC_NOVTABLE IDerivedInterface : public IBaseInterface
+{
+  virtual void DerivedMethod() = 0;
+};
+
+MSO_CLASS_GUID(MyClass, "866E3389-0194-4416-94CE-6BE8A5185387")
+class MyClass
+{
+  virtual void DerivedMethod() = 0;
+};
+
+MSO_STRUCT_GUID(AlreadyDefinedType1, "BAA524C8-F5D1-4CE7-AE24-1FF5EAB306B2")
+struct AlreadyDefinedType1
+{
+  virtual void Method() = 0;
+};
+
+MSO_CLASS_GUID(AlreadyDefinedType2, "8C76ECFE-0715-4DA1-9746-2FD4DE39118F")
+class AlreadyDefinedType2
+{
+  virtual void Method() = 0;
+};
+
+class TypeWithoutGuid
+{
+};
+
+// Associate GUIDs in a namespace
+namespace MyAppTest { namespace MyDetails {
+
+MSO_STRUCT_GUID(IBaseInterface2, "86DE7178-00E6-4A40-8B2C-BA2FBFFB4D06")
+struct DECLSPEC_NOVTABLE IBaseInterface2
+{
+  virtual void BaseMethod() = 0;
+};
+
+MSO_STRUCT_GUID(IDerivedInterface2, "C91CAD11-98AB-4218-952F-87509F8F2116")
+struct DECLSPEC_NOVTABLE IDerivedInterface2 : public IBaseInterface2
+{
+  virtual void DerivedMethod() = 0;
+};
+
+MSO_CLASS_GUID(MyClass2, "06A68045-D24C-4816-84DC-C18888EC46A9")
+class MyClass2
+{
+  virtual void DerivedMethod() = 0;
+};
+
+MSO_STRUCT_GUID(AlreadyDefinedType21, "6B2050DF-6C60-48ED-809D-A88B2476E5A2")
+struct AlreadyDefinedType21
+{
+  virtual void Method() = 0;
+};
+
+MSO_CLASS_GUID(AlreadyDefinedType22, "78CEA0B9-2AC5-4FD0-8EE8-C02836BE800D")
+class AlreadyDefinedType22
+{
+  virtual void Method() = 0;
+};
+
+class TypeWithoutGuid2
+{
+};
+
+}} // namespace MyAppTest::MyDetails
+
+// Test that we can pass __uuidof() as a template parameter
+template <const IID& clsid>
+struct MyGuidHolder
+{
+  const IID& GetGuid() const noexcept
+  {
+    UNREFERENCED_PARAMETER(this);
+    return clsid;
+  }
+};
+
+MSO_DEFINE_GUID_TOKEN(MyProductId, "67A42775-79F7-469D-8A28-7348ED9F8D71")
+
+namespace MyAppTest { namespace MyDetails {
+
+MSO_DEFINE_GUID_TOKEN(MyProductId2, "AABFD353-B463-41A2-B04C-9A6AB7541D20")
+
+}} // namespace MyAppTest::MyDetails
+
+MSO_DEFINE_GUID_TOKEN(FailingToParseId, "A39D5FC8-0641-4EEE-8C97-DDEF114D487D")
+
+TestClassComponent(GuidTest, Mso.Guid)
+    TEST_CLASS (GuidTest){static std::string GuidToString(const GUID& guid){char str[37];
+sprintf_s(
+    str,
+    _countof(str),
+    "%08lX-%04hX-%04hX-%02hhX%02hhX-%02hhX%02hhX%02hhX%02hhX%02hhX%02hhX",
+    guid.Data1,
+    guid.Data2,
+    guid.Data3,
+    guid.Data4[0],
+    guid.Data4[1],
+    guid.Data4[2],
+    guid.Data4[3],
+    guid.Data4[4],
+    guid.Data4[5],
+    guid.Data4[6],
+    guid.Data4[7]);
+return str;
+}
+
+TEST_METHOD(TestTypeGuids)
+{
+  TestAssert::AreEqual(std::string("38E23DC7-92B1-4B21-B5FE-6EA786817915"), GuidToString(__uuidof(IBaseInterface)));
+  TestAssert::AreEqual(std::string("9E11BC42-1416-45B1-9712-AA4AAD87F78B"), GuidToString(__uuidof(IDerivedInterface)));
+  TestAssert::AreEqual(std::string("866E3389-0194-4416-94CE-6BE8A5185387"), GuidToString(__uuidof(MyClass)));
+  TestAssert::AreEqual(
+      std::string("BAA524C8-F5D1-4CE7-AE24-1FF5EAB306B2"), GuidToString(__uuidof(AlreadyDefinedType1)));
+  TestAssert::AreEqual(
+      std::string("8C76ECFE-0715-4DA1-9746-2FD4DE39118F"), GuidToString(__uuidof(AlreadyDefinedType2)));
+}
+
+TEST_METHOD(TestTypeGuids_InNamespace)
+{
+  TestAssert::AreEqual(
+      std::string("86DE7178-00E6-4A40-8B2C-BA2FBFFB4D06"),
+      GuidToString(__uuidof(MyAppTest::MyDetails::IBaseInterface2)));
+  TestAssert::AreEqual(
+      std::string("C91CAD11-98AB-4218-952F-87509F8F2116"),
+      GuidToString(__uuidof(MyAppTest::MyDetails::IDerivedInterface2)));
+  TestAssert::AreEqual(
+      std::string("06A68045-D24C-4816-84DC-C18888EC46A9"), GuidToString(__uuidof(MyAppTest::MyDetails::MyClass2)));
+  TestAssert::AreEqual(
+      std::string("6B2050DF-6C60-48ED-809D-A88B2476E5A2"),
+      GuidToString(__uuidof(MyAppTest::MyDetails::AlreadyDefinedType21)));
+  TestAssert::AreEqual(
+      std::string("78CEA0B9-2AC5-4FD0-8EE8-C02836BE800D"),
+      GuidToString(__uuidof(MyAppTest::MyDetails::AlreadyDefinedType22)));
+}
+
+TEST_METHOD(TestTypeGuids_uuidof_AsTemplateParameter)
+{
+  auto h1 = MyGuidHolder<__uuidof(IBaseInterface)>();
+  TestAssert::AreEqual(std::string("38E23DC7-92B1-4B21-B5FE-6EA786817915"), GuidToString(h1.GetGuid()));
+  auto h2 = MyGuidHolder<__uuidof(MyAppTest::MyDetails::IBaseInterface2)>();
+  TestAssert::AreEqual(std::string("86DE7178-00E6-4A40-8B2C-BA2FBFFB4D06"), GuidToString(h2.GetGuid()));
+}
+
+TEST_METHOD(TestTypeGuids_TypeHasGuid)
+{
+  TestAssert::IsTrue(Mso::TypeHasGuid<IBaseInterface>::Value);
+  TestAssert::IsTrue(Mso::TypeHasGuid<IDerivedInterface>::Value);
+  TestAssert::IsTrue(Mso::TypeHasGuid<MyClass>::Value);
+  TestAssert::IsTrue(Mso::TypeHasGuid<AlreadyDefinedType1>::Value);
+  TestAssert::IsTrue(Mso::TypeHasGuid<AlreadyDefinedType2>::Value);
+  TestAssert::IsFalse(Mso::TypeHasGuid<TypeWithoutGuid>::Value);
+
+  TestAssert::IsTrue(Mso::TypeHasGuid<MyAppTest::MyDetails::IBaseInterface2>::Value);
+  TestAssert::IsTrue(Mso::TypeHasGuid<MyAppTest::MyDetails::IDerivedInterface2>::Value);
+  TestAssert::IsTrue(Mso::TypeHasGuid<MyAppTest::MyDetails::MyClass2>::Value);
+  TestAssert::IsTrue(Mso::TypeHasGuid<MyAppTest::MyDetails::AlreadyDefinedType21>::Value);
+  TestAssert::IsTrue(Mso::TypeHasGuid<MyAppTest::MyDetails::AlreadyDefinedType22>::Value);
+  TestAssert::IsFalse(Mso::TypeHasGuid<MyAppTest::MyDetails::TypeWithoutGuid2>::Value);
+}
+
+TEST_METHOD(TestTypeGuids_DefineGuidToken)
+{
+  TestAssert::AreEqual(std::string("67A42775-79F7-469D-8A28-7348ED9F8D71"), GuidToString(__uuidof_token(MyProductId)));
+  TestAssert::AreEqual(
+      std::string("AABFD353-B463-41A2-B04C-9A6AB7541D20"),
+      GuidToString(__uuidof_token(MyAppTest::MyDetails::MyProductId2)));
+  TestAssert::AreEqual(
+      std::string("A39D5FC8-0641-4EEE-8C97-DDEF114D487D"), GuidToString(__uuidof_token(FailingToParseId)));
+}
+}
+;

--- a/libs/memoryApi/CMakeLists.txt
+++ b/libs/memoryApi/CMakeLists.txt
@@ -4,12 +4,12 @@
 liblet(memoryApi
   DEPENDS
     Mso::compilerAdapters
-    Mso::cppType
     Mso::crash
     Mso::debugAssertApi
     Mso::oacr
     Mso::smartPtr
     Mso::tagUtils
+    Mso::typeTraits
   DEPENDS_POSIX
     Mso::platform_posix
 )

--- a/libs/motifCpp/CMakeLists.txt
+++ b/libs/motifCpp/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 liblet(motifCpp
   DEPENDS
+    Mso::crash
     Mso::oacr
     Mso::platformAdapters
 )

--- a/libs/motifCpp/include/CMakeLists.txt
+++ b/libs/motifCpp/include/CMakeLists.txt
@@ -8,8 +8,8 @@ liblet_includes(
     motifCpp/libletAwareMemLeakDetection.h
     motifCpp/motifCppTest.h
     motifCpp/motifCppTestBase.h
-    motifCpp/testInfo.h
     motifCpp/testCheck.h
+    motifCpp/testInfo.h
     test/skipSEHUT.h
   INCLUDES_APPLE
     motifCpp/assert_IgnorePlat_apple.h

--- a/libs/motifCpp/include/motifCpp/assert_IgnorePlat_emptyImpl.h
+++ b/libs/motifCpp/include/motifCpp/assert_IgnorePlat_emptyImpl.h
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+#pragma once
+#ifndef MSO_MOTIFCPP_ASSERT_IGNOREPLAT_EMPTYIMPL_H
+#define MSO_MOTIFCPP_ASSERT_IGNOREPLAT_EMPTYIMPL_H
+
 /*----------------------------------------------------------------------------
     MotifCpp assert APIs
 ----------------------------------------------------------------------------*/
-#pragma once
-#ifndef MOTIFCPP_ASSERT_IGNOREPLAT_EMPTYIMPL_H
-#define MOTIFCPP_ASSERT_IGNOREPLAT_EMPTYIMPL_H
 
 #include <cstdint>
 
@@ -24,4 +25,4 @@ public:
 
 } // namespace Mso
 
-#endif // MOTIFCPP_ASSERT_IGNOREPLAT_EMPTYIMPL_H
+#endif // MSO_MOTIFCPP_ASSERT_IGNOREPLAT_EMPTYIMPL_H

--- a/libs/motifCpp/include/motifCpp/assert_motifApi.h
+++ b/libs/motifCpp/include/motifCpp/assert_motifApi.h
@@ -2,8 +2,9 @@
 // Licensed under the MIT license.
 
 #pragma once
-#ifndef MOTIFCPP_ASSERT_MOTIFAPI_H
-#define MOTIFCPP_ASSERT_MOTIFAPI_H
+#ifndef MSO_MOTIFCPP_ASSERT_MOTIFAPI_H
+#define MSO_MOTIFCPP_ASSERT_MOTIFAPI_H
+
 #include "motifCppTest.h"
 
 #define BeginSupportFileMap()
@@ -12,4 +13,4 @@
 
 #define EndSupportFileMap()
 
-#endif // MOTIFCPP_ASSERT_MOTIFAPI_H
+#endif // MSO_MOTIFCPP_ASSERT_MOTIFAPI_H

--- a/libs/motifCpp/include/motifCpp/gTestAdapter.h
+++ b/libs/motifCpp/include/motifCpp/gTestAdapter.h
@@ -2,14 +2,13 @@
 // Licensed under the MIT license.
 
 #pragma once
-
-#ifndef GTESTADAPTER_H
-#define GTESTADAPTER_H
+#ifndef MSO_MOTIFCPP_GTESTADAPTER_H
+#define MSO_MOTIFCPP_GTESTADAPTER_H
 
 #include "gtest/gtest.h"
 #include <motifCpp/testInfo.h>
 
-namespace Mso { namespace UnitTests { namespace GTest {
+namespace Mso::UnitTests::GTest {
 
 struct GTestFixture : ::testing::Test
 {
@@ -36,13 +35,50 @@ private:
   std::unique_ptr<TestClass> m_test;
 };
 
+template <int&... ExplicitParameterBarrier, typename Factory>
+inline auto RegisterTest(
+    const char* test_suite_name,
+    const char* test_name,
+    const char* type_param,
+    const char* value_param,
+    const char* file,
+    int line,
+    Factory factory)
+{
+  using TestT = typename std::remove_pointer<decltype(factory())>::type;
+
+  class FactoryImpl : public ::testing::internal::TestFactoryBase
+  {
+  public:
+    explicit FactoryImpl(Factory f) : factory_(std::move(f)) {}
+    ::testing::Test* CreateTest() override
+    {
+      return factory_();
+    }
+
+  private:
+    Factory factory_;
+  };
+
+  return ::testing::internal::MakeAndRegisterTestInfo(
+      test_suite_name,
+      test_name,
+      type_param,
+      value_param,
+      ::testing::internal::CodeLocation(file, line),
+      ::testing::internal::GetTypeId<TestT>(),
+      TestT::SetUpTestCase,
+      TestT::TearDownTestCase,
+      new FactoryImpl{std::move(factory)});
+}
+
 inline void RegisterUnitTests()
 {
   for (const TestClassInfo* classInfo : TestClassInfo::ClassInfos())
   {
     for (const TestMethodInfo* methodInfo : classInfo->MethodInfos())
     {
-      ::testing::RegisterTest(
+      RegisterTest(
           /*test_suite_name:*/ classInfo->ClassName(),
           /*test_name:*/ methodInfo->MethodName(),
           /*type_param:*/ nullptr,
@@ -56,6 +92,6 @@ inline void RegisterUnitTests()
   }
 }
 
-}}} // namespace Mso::UnitTests::GTest
+} // namespace Mso::UnitTests::GTest
 
-#endif // GTESTADAPTER_H
+#endif // MSO_MOTIFCPP_GTESTADAPTER_H

--- a/libs/motifCpp/include/motifCpp/libletAwareMemLeakDetection.h
+++ b/libs/motifCpp/include/motifCpp/libletAwareMemLeakDetection.h
@@ -1,13 +1,23 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#include <motifCpp/assert_motifApi.h>
+#pragma once
+#ifndef MSO_MOTIFCPP_LIBLETAWAREMEMLEAKDETECTION_H
+#define MSO_MOTIFCPP_LIBLETAWAREMEMLEAKDETECTION_H
+
+#include "motifCpp/assert_motifApi.h"
 
 // TODO: Implement this as needed
-class LibletAwareMemLeakDetection : public MotifCppTestBase
+struct LibletAwareMemLeakDetection : MotifCppTestBase
 {
 protected:
   void InitLiblets() noexcept {}
 
   void UninitLiblets() noexcept {}
+
+public:
+  virtual void StartTrackingMemoryAllocations() {}
+  virtual void StopTrackingMemoryAllocations() {}
 };
+
+#endif // MSO_MOTIFCPP_LIBLETAWAREMEMLEAKDETECTION_H

--- a/libs/motifCpp/include/motifCpp/motifCppTest.h
+++ b/libs/motifCpp/include/motifCpp/motifCppTest.h
@@ -2,369 +2,28 @@
 // Licensed under the MIT license.
 
 #pragma once
-#ifndef MSO_MOTIFCPP_MOTIFCPPTEST_H
-#define MSO_MOTIFCPP_MOTIFCPPTEST_H
 
 #include <csetjmp>
 #include <csignal>
 #include <cstdarg>
 #include <functional>
-#include <string>
 #include <type_traits>
-#include <platformAdapters/IUnknownShim.h>
-#include <motifCpp/gTestAdapter.h>
-#include <oacr/oacr.h>
+
 #include <compilerAdapters/compilerWarnings.h>
+#include <oacr/oacr.h>
+#include <platformAdapters/IUnknownShim.h>
 
-using WCHAR = wchar_t;
+#if defined(MSO_USE_GTEST)
+#include <motifCpp/gTestAdapter.h>
+#elif defined(MSO_USE_XCTEST)
+#include <motifCpp/xcTestAdapter.h>
+#else
+#error "Undefined unit test framework"
+#endif
 
-#define GTEST_ASSERT_AT_(file, line, expression, on_failure)    \
-  GTEST_AMBIGUOUS_ELSE_BLOCKER_                                 \
-  if (const ::testing::AssertionResult gtest_ar = (expression)) \
-    ;                                                           \
-  else                                                          \
-    on_failure(file, line, gtest_ar.failure_message())
-
-#define GTEST_FATAL_FAILURE_AT_(file, line, message) \
-  return GTEST_MESSAGE_AT_(file, line, message, ::testing::TestPartResult::kFatalFailure)
+typedef wchar_t WCHAR;
 
 namespace TestAssert {
-
-inline std::string FormatMsg(char const* format, ...) noexcept
-{
-  std::string result;
-  va_list vlist;
-  va_start(vlist, format);
-  auto size = std::vsnprintf(nullptr, 0, format, vlist);
-  result.append(size + 1, '\0');
-  std::vsnprintf(&result[0], size + 1, format, vlist);
-  result.resize(size);
-  va_end(vlist);
-  return result;
-}
-
-inline std::string FormatCustomMsg(int line, char const* message = "")
-{
-  return FormatMsg(
-      "    Line: %d%s%s",
-      line,
-      (message == nullptr || message[0] == '\0') ? "" : "\n",
-      message == nullptr ? "" : message);
-}
-
-inline void FailInternalAt(char const* file, int line, char const* message, std::string&& errorMessage)
-{
-  GTEST_FATAL_FAILURE_AT_(file, line, "") << errorMessage << FormatCustomMsg(line, message).c_str();
-}
-
-inline void FailAt(char const* file, int line, char const* message = "")
-{
-  FailInternalAt(file, line, message, "Failed\n");
-}
-
-inline void IsTrueAt(char const* file, int line, bool condition, char const* exprStr, char const* message = "")
-{
-  if (!condition)
-  {
-    FailInternalAt(
-        file,
-        line,
-        message,
-        FormatMsg(
-            "Expected: [ %s ] is true\n"
-            "  Actual: it is false\n",
-            exprStr));
-  }
-}
-
-template <class T, std::enable_if_t<!std::is_same_v<bool, T>, int> = 1>
-inline void IsTrueAt(char const* file, int line, T condition, char const* exprStr, char const* message = "")
-{
-  return IsTrueAt(file, line, !!condition, exprStr, message);
-}
-
-template <class TExpected, class TActual>
-inline void AreEqualAt(
-    char const* file,
-    int line,
-    TExpected const& expected,
-    TActual const& actual,
-    char const* expectedExpr,
-    char const* actualExpr,
-    char const* message = "")
-{
-  GTEST_ASSERT_AT_(
-      file,
-      line,
-      ::testing::internal::EqHelper::Compare(expectedExpr, actualExpr, expected, actual),
-      GTEST_FATAL_FAILURE_AT_)
-      << FormatCustomMsg(line, message);
-}
-
-template <
-    class TExpected,
-    class TActual,
-    std::enable_if_t<
-        std::is_same_v<TExpected, TActual> && !std::is_same_v<TExpected, WCHAR> && !std::is_same_v<TExpected, char>,
-        int> = 1>
-void AreEqualAt(
-    char const* file,
-    int line,
-    TExpected const* expected,
-    TActual const* actual,
-    char const* expectedExpr,
-    char const* actualExpr,
-    char const* message = "")
-{
-  GTEST_ASSERT_AT_(
-      file,
-      line,
-      ::testing::internal::EqHelper<GTEST_IS_NULL_LITERAL_(expected)>::Compare(
-          expectedExpr, actualExpr, expected, actual),
-      GTEST_FATAL_FAILURE_AT_)
-      << FormatCustomMsg(line, message);
-}
-
-inline void AreEqualAt(
-    char const* file,
-    int line,
-    WCHAR const* expected,
-    WCHAR const* actual,
-    char const* expectedExpr,
-    char const* actualExpr,
-    char const* message = "")
-{
-  GTEST_ASSERT_AT_(
-      file,
-      line,
-      ::testing::internal::CmpHelperSTREQ(expectedExpr, actualExpr, expected, actual),
-      GTEST_FATAL_FAILURE_AT_)
-      << FormatCustomMsg(line, message);
-}
-
-inline void AreEqualAt(
-    char const* file,
-    int line,
-    char const* expected,
-    char const* actual,
-    char const* expectedExpr,
-    char const* actualExpr,
-    char const* message = "")
-{
-  GTEST_ASSERT_AT_(
-      file,
-      line,
-      ::testing::internal::CmpHelperSTREQ(expectedExpr, actualExpr, expected, actual),
-      GTEST_FATAL_FAILURE_AT_)
-      << FormatCustomMsg(line, message);
-}
-
-inline void AreEqualAt(
-    char const* file,
-    int line,
-    WCHAR* expected,
-    WCHAR const* actual,
-    char const* expectedExpr,
-    char const* actualExpr,
-    char const* message = "")
-{
-  GTEST_ASSERT_AT_(
-      file,
-      line,
-      ::testing::internal::CmpHelperSTREQ(expectedExpr, actualExpr, expected, actual),
-      GTEST_FATAL_FAILURE_AT_)
-      << FormatCustomMsg(line, message);
-}
-
-inline void AreEqualAt(
-    char const* file,
-    int line,
-    char* expected,
-    const char* actual,
-    char const* expectedExpr,
-    char const* actualExpr,
-    const char* message = "")
-{
-  GTEST_ASSERT_AT_(
-      file,
-      line,
-      ::testing::internal::CmpHelperSTREQ(expectedExpr, actualExpr, expected, actual),
-      GTEST_FATAL_FAILURE_AT_)
-      << FormatCustomMsg(line, message);
-}
-
-// Code used for all the C++ exceptions
-constexpr uint32_t EXCEPTION_CPLUSPLUS = static_cast<uint32_t>(0xE06D7363);
-
-inline uint32_t FilterCrashExceptions(uint32_t exceptionCode) noexcept
-{
-  if ((exceptionCode == EXCEPTION_BREAKPOINT) // allow exceptions to get to the debugger
-      || (exceptionCode == EXCEPTION_SINGLE_STEP) // allow exceptions to get to the debugger
-      || (exceptionCode == EXCEPTION_GUARD_PAGE) // allow to crash on memory page access violation
-      || (exceptionCode == EXCEPTION_STACK_OVERFLOW)) // allow to crash on stack overflow
-  {
-    return EXCEPTION_CONTINUE_SEARCH;
-  }
-
-  if (exceptionCode == EXCEPTION_CPLUSPLUS) // log C++ exception and pass it through
-  {
-    FailAt(__FILE__, __LINE__, "Test function did not crash, but exception is thrown!");
-    return EXCEPTION_CONTINUE_SEARCH;
-  }
-
-  return EXCEPTION_EXECUTE_HANDLER;
-}
-
-BEGIN_DISABLE_WARNING_UNREACHABLE_CODE()
-template <class TLambda>
-inline bool ExpectCrashCore(TLambda const& lambda)
-{
-  __try
-  {
-    lambda();
-    return false;
-  }
-  __except (FilterCrashExceptions(GetExceptionCode()))
-  {
-    return true;
-  }
-}
-END_DISABLE_WARNING_UNREACHABLE_CODE()
-
-template <class TLambda>
-inline void
-ExpectCrashAt(char const* file, int line, TLambda const& lambda, char const* exprStr, char const* message = "")
-{
-  if (!ExpectCrashCore(lambda))
-  {
-    FailInternalAt(
-        file,
-        line,
-        message,
-        FormatMsg(
-            "Expected: [ %s ] must crash\n"
-            "  Actual: it does not crash\n",
-            exprStr));
-  }
-}
-
-struct TerminateHandlerRestorer
-{
-  ~TerminateHandlerRestorer() noexcept
-  {
-    std::set_terminate(Handler);
-  }
-
-  std::terminate_handler Handler;
-};
-
-BEGIN_DISABLE_WARNING_FUNCTION_MAY_NOT_CALL_DTOR()
-template <class TLambda>
-inline bool ExpectTerminateCore(TLambda const& lambda)
-{
-  static jmp_buf buf;
-
-  // Set a terminate handler and save the previous terminate handler to be restored in the end of function.
-  TerminateHandlerRestorer terminateRestore = {std::set_terminate([]() { longjmp(buf, 1); })};
-
-  // setjmp originally returns 0, and when longjmp is called it returns 1.
-  if (!setjmp(buf))
-  {
-    lambda();
-    return false; // must not be executed if fn() caused termination and the longjmp is executed.
-  }
-  else
-  {
-    return true; // executed if longjmp is executed in the terminate handler.
-  }
-}
-END_DISABLE_WARNING_FUNCTION_MAY_NOT_CALL_DTOR()
-
-template <class TLambda>
-inline void
-ExpectTerminateAt(char const* file, int line, TLambda const& lambda, char const* exprStr, char const* message = "")
-{
-  if (!ExpectTerminateCore(lambda))
-  {
-    FailInternalAt(
-        file,
-        line,
-        message,
-        FormatMsg(
-            "Expected: [ %s ] must terminate\n"
-            "  Actual: it does not terminate\n",
-            exprStr));
-  }
-}
-
-template <class TException, class TLambda>
-inline void ExpectExceptionAt(
-    char const* file,
-    int line,
-    TLambda const& lambda,
-    char const* exceptionStr,
-    char const* exprStr,
-    char const* message = "")
-{
-  char const* actualIssue = "";
-  bool isFailed = false;
-  bool isExpectedExceptionCaught = false;
-
-  try
-  {
-    lambda();
-  }
-  catch (TException const&)
-  {
-    isExpectedExceptionCaught = true;
-  }
-  catch (...)
-  {
-    isFailed = true;
-    actualIssue = "it throws a different type";
-  }
-
-  if (!isExpectedExceptionCaught && !isFailed)
-  {
-    isFailed = true;
-    actualIssue = "it does not throw";
-  }
-
-  if (isFailed)
-  {
-    FailInternalAt(
-        file,
-        line,
-        message,
-        FormatMsg(
-            "Expected: [ %s ] throws an exception of type %s\n"
-            "  Actual: %s\n",
-            exprStr,
-            exceptionStr,
-            actualIssue));
-  }
-}
-
-template <class TLambda>
-inline void
-ExpectNoThrowAt(char const* file, int line, TLambda const& lambda, char const* exprStr, char const* message = "")
-{
-  try
-  {
-    lambda();
-  }
-  catch (...)
-  {
-    FailInternalAt(
-        file,
-        line,
-        message,
-        FormatMsg(
-            "Expected: [ %s ] does not throw an exception\n"
-            "  Actual: it throws an exception\n",
-            exprStr));
-  }
-}
 
 // Asserts that the specified condition is true, if it is false the unit test will fail
 inline void IsTrue(bool condition, _In_z_ const WCHAR* message = L"")
@@ -403,15 +62,14 @@ template <
     typename ExpectedType,
     typename ActualType,
     typename TEnable = typename std::enable_if<
-        std::is_same<ExpectedType, ActualType>::value && !std::is_same<ExpectedType, WCHAR>::value
+        std::is_same<ExpectedType, ActualType>::value && !std::is_same<ExpectedType, wchar_t>::value
         && !std::is_same<ExpectedType, char>::value>::type>
 void AreEqual(_In_ const ExpectedType* expected, _In_ const ActualType* actual, _In_z_ const WCHAR* message = L"")
 {
-  std::wstring wstrMessage(message);
-  ASSERT_EQ(expected, actual) << wstrMessage.c_str();
+  AreEqual(*expected, *actual, message);
 }
 
-inline void AreEqual(_In_ const WCHAR* expected, _In_ const WCHAR* actual, _In_z_ const WCHAR* message = L"")
+inline void AreEqual(_In_ const wchar_t* expected, _In_ const wchar_t* actual, _In_z_ const WCHAR* message = L"")
 {
   std::wstring wstrMessage(message);
   ASSERT_STREQ(expected, actual) << wstrMessage.c_str();
@@ -423,7 +81,7 @@ inline void AreEqual(_In_ const char* expected, _In_ const char* actual, _In_z_ 
   ASSERT_STREQ(expected, actual) << wstrMessage.c_str();
 }
 
-inline void AreEqual(_In_ WCHAR* expected, _In_ const WCHAR* actual, _In_z_ const WCHAR* message = L"")
+inline void AreEqual(_In_ wchar_t* expected, _In_ const wchar_t* actual, _In_z_ const WCHAR* message = L"")
 {
   std::wstring wstrMessage(message);
   ASSERT_STREQ(expected, actual) << wstrMessage.c_str();
@@ -447,14 +105,14 @@ template <
     typename ExpectedType,
     typename ActualType,
     typename TEnable = typename std::enable_if<
-        std::is_same<ExpectedType, ActualType>::value && !std::is_same<ExpectedType, WCHAR>::value
+        std::is_same<ExpectedType, ActualType>::value && !std::is_same<ExpectedType, wchar_t>::value
         && !std::is_same<ExpectedType, char>::value>::type>
 void AreNotEqual(_In_ const ExpectedType* expected, _In_ const ActualType* actual, _In_z_ const WCHAR* message = L"")
 {
   AreNotEqual(*expected, *actual, message);
 }
 
-inline void AreNotEqual(_In_ const WCHAR* expected, _In_ const WCHAR* actual, _In_z_ const WCHAR* message = L"")
+inline void AreNotEqual(_In_ const wchar_t* expected, _In_ const wchar_t* actual, _In_z_ const WCHAR* message = L"")
 {
   std::wstring wstrMessage(message);
   ASSERT_STRNE(expected, actual) << wstrMessage.c_str();
@@ -466,7 +124,7 @@ inline void AreNotEqual(_In_ const char* expected, _In_ const char* actual, _In_
   ASSERT_STRNE(expected, actual) << wstrMessage.c_str();
 }
 
-inline void AreNotEqual(_In_ WCHAR* expected, _In_ const WCHAR* actual, _In_z_ const WCHAR* message = L"")
+inline void AreNotEqual(_In_ wchar_t* expected, _In_ const wchar_t* actual, _In_z_ const WCHAR* message = L"")
 {
   std::wstring wstrMessage(message);
   ASSERT_STRNE(expected, actual) << wstrMessage.c_str();
@@ -531,7 +189,7 @@ inline void ExpectException(const std::function<void()>& statement, const WCHAR*
 template <typename ExceptionType>
 inline void ExpectException(
     const std::function<void()>& statement,
-    const std::function<void()>& onException,
+    const std::function<void()>& /*onException*/,
     const WCHAR* message = L"")
 {
   EXPECT_THROW(statement(), ExceptionType) << message;
@@ -552,15 +210,106 @@ inline void HrFailed(HRESULT hr, _In_z_ const WCHAR* message = L"")
   ASSERT_FALSE(SUCCEEDED(hr)) << message;
 }
 
+#ifdef MS_TARGET_WINDOWS
+// Code used for all the C++ exceptions
+static const DWORD EXCEPTION_CPLUSPLUS = static_cast<DWORD>(0xE06D7363);
+
+inline DWORD FilterCrashExceptions(DWORD exceptionCode) noexcept
+{
+  if ((exceptionCode == EXCEPTION_BREAKPOINT) // allow exceptions to get to the debugger
+      || (exceptionCode == EXCEPTION_SINGLE_STEP) // allow exceptions to get to the debugger
+      || (exceptionCode == EXCEPTION_GUARD_PAGE) // allow to crash on memory page access violation
+      || (exceptionCode == EXCEPTION_STACK_OVERFLOW)) // allow to crash on stack overflow
+  {
+    return EXCEPTION_CONTINUE_SEARCH;
+  }
+  if (exceptionCode == EXCEPTION_CPLUSPLUS) // log C++ exception and pass it through
+  {
+    TestAssert::Fail(L"Test function did not crash, but exception is thrown!");
+    return EXCEPTION_CONTINUE_SEARCH;
+  }
+  return EXCEPTION_EXECUTE_HANDLER;
+}
+
+BEGIN_DISABLE_WARNING_UNREACHABLE_CODE()
+template <typename Fn>
+inline bool ExpectCrashCore(const Fn& fn, const WCHAR* /*message*/)
+{
+  __try
+  {
+    fn();
+  }
+  __except (FilterCrashExceptions(GetExceptionCode()))
+  {
+    // Pass(message == nullptr || message[0] == L'\0' ? L"Crash occurred as expected." : message);
+    return true;
+  }
+  // Fail(message == nullptr || message[0] == L'\0' ? L"Test function did not crash!" : message);
+  return false;
+}
+END_DISABLE_WARNING_UNREACHABLE_CODE()
+
+#else
+
+using SigAction = void (*)(int, siginfo_t*, void*);
+
+// An RAII class that sets custom action for segmentation fault signal and
+// restores the old one in the destructor.
+struct CrashState
+{
+  CrashState(SigAction action) noexcept
+  {
+    sigemptyset(&m_action.sa_mask);
+    m_action.sa_sigaction = action;
+    m_action.sa_flags = SA_NODEFER;
+    sigaction(SIGSEGV, &m_action, &m_oldAction);
+  }
+
+  ~CrashState() noexcept
+  {
+    sigaction(SIGSEGV, &m_oldAction, nullptr);
+  }
+
+private:
+  struct sigaction m_action
+  {
+  };
+  struct sigaction m_oldAction
+  {
+  };
+};
+
+// Returns true if crash (segmentation fault happened)
+template <class Fn>
+inline bool ExpectCrashCore(const Fn& fn, const WCHAR* /*message*/)
+{
+  static sigjmp_buf buf{};
+
+  // Set sigaction and save the previous action to be restored in the end of
+  // function.
+  CrashState crashState{[](int /*signal*/, siginfo_t* /*si*/, void* /*arg*/) { longjmp(buf, 1); }};
+
+  // setjmp originally returns 0, and when longjmp is called it returns 1.
+  if (!setjmp(buf))
+  {
+    fn();
+    return true; // must not be executed if fn() caused crash and the longjmp is executed.
+  }
+  else
+  {
+    return true; // executed if longjmp is executed in the SigAction handler.
+  }
+}
+
+#endif
+
 template <typename Fn>
 inline void ExpectVEC(const Fn& fn, const WCHAR* message = L"")
 {
-  if (!ExpectCrashCore(fn))
+  if (!ExpectCrashCore(fn, message))
   {
     Fail(message);
   }
 }
 
 } // namespace TestAssert
-
-#endif // MSO_MOTIFCPP_MOTIFCPPTEST_H

--- a/libs/motifCpp/include/motifCpp/motifCppTest.h
+++ b/libs/motifCpp/include/motifCpp/motifCppTest.h
@@ -11,9 +11,10 @@
 #include <functional>
 #include <string>
 #include <type_traits>
-#include "platformAdapters/IUnknownShim.h"
-#include "motifCpp/gTestAdapter.h"
-#include "oacr/oacr.h"
+#include <platformAdapters/IUnknownShim.h>
+#include <motifCpp/gTestAdapter.h>
+#include <oacr/oacr.h>
+#include <compilerAdapters/compilerWarnings.h>
 
 using WCHAR = wchar_t;
 
@@ -214,6 +215,7 @@ inline uint32_t FilterCrashExceptions(uint32_t exceptionCode) noexcept
   return EXCEPTION_EXECUTE_HANDLER;
 }
 
+BEGIN_DISABLE_WARNING_UNREACHABLE_CODE()
 template <class TLambda>
 inline bool ExpectCrashCore(TLambda const& lambda)
 {
@@ -227,6 +229,7 @@ inline bool ExpectCrashCore(TLambda const& lambda)
     return true;
   }
 }
+END_DISABLE_WARNING_UNREACHABLE_CODE()
 
 template <class TLambda>
 inline void

--- a/libs/motifCpp/include/motifCpp/motifCppTest.h
+++ b/libs/motifCpp/include/motifCpp/motifCppTest.h
@@ -2,28 +2,366 @@
 // Licensed under the MIT license.
 
 #pragma once
+#ifndef MSO_MOTIFCPP_MOTIFCPPTEST_H
+#define MSO_MOTIFCPP_MOTIFCPPTEST_H
 
 #include <csetjmp>
 #include <csignal>
 #include <cstdarg>
 #include <functional>
+#include <string>
 #include <type_traits>
+#include "platformAdapters/IUnknownShim.h"
+#include "motifCpp/gTestAdapter.h"
+#include "oacr/oacr.h"
 
-#include <compilerAdapters/compilerWarnings.h>
-#include <oacr/oacr.h>
-#include <platformAdapters/IUnknownShim.h>
+using WCHAR = wchar_t;
 
-#if defined(MSO_USE_GTEST)
-#include <motifCpp/gTestAdapter.h>
-#elif defined(MSO_USE_XCTEST)
-#include <motifCpp/xcTestAdapter.h>
-#else
-#error "Undefined unit test framework"
-#endif
+#define GTEST_ASSERT_AT_(file, line, expression, on_failure)    \
+  GTEST_AMBIGUOUS_ELSE_BLOCKER_                                 \
+  if (const ::testing::AssertionResult gtest_ar = (expression)) \
+    ;                                                           \
+  else                                                          \
+    on_failure(file, line, gtest_ar.failure_message())
 
-typedef wchar_t WCHAR;
+#define GTEST_FATAL_FAILURE_AT_(file, line, message) \
+  return GTEST_MESSAGE_AT_(file, line, message, ::testing::TestPartResult::kFatalFailure)
 
 namespace TestAssert {
+
+inline std::string FormatMsg(char const* format, ...) noexcept
+{
+  std::string result;
+  va_list vlist;
+  va_start(vlist, format);
+  auto size = std::vsnprintf(nullptr, 0, format, vlist);
+  result.append(size + 1, '\0');
+  std::vsnprintf(&result[0], size + 1, format, vlist);
+  result.resize(size);
+  va_end(vlist);
+  return result;
+}
+
+inline std::string FormatCustomMsg(int line, char const* message = "")
+{
+  return FormatMsg(
+      "    Line: %d%s%s",
+      line,
+      (message == nullptr || message[0] == '\0') ? "" : "\n",
+      message == nullptr ? "" : message);
+}
+
+inline void FailInternalAt(char const* file, int line, char const* message, std::string&& errorMessage)
+{
+  GTEST_FATAL_FAILURE_AT_(file, line, "") << errorMessage << FormatCustomMsg(line, message).c_str();
+}
+
+inline void FailAt(char const* file, int line, char const* message = "")
+{
+  FailInternalAt(file, line, message, "Failed\n");
+}
+
+inline void IsTrueAt(char const* file, int line, bool condition, char const* exprStr, char const* message = "")
+{
+  if (!condition)
+  {
+    FailInternalAt(
+        file,
+        line,
+        message,
+        FormatMsg(
+            "Expected: [ %s ] is true\n"
+            "  Actual: it is false\n",
+            exprStr));
+  }
+}
+
+template <class T, std::enable_if_t<!std::is_same_v<bool, T>, int> = 1>
+inline void IsTrueAt(char const* file, int line, T condition, char const* exprStr, char const* message = "")
+{
+  return IsTrueAt(file, line, !!condition, exprStr, message);
+}
+
+template <class TExpected, class TActual>
+inline void AreEqualAt(
+    char const* file,
+    int line,
+    TExpected const& expected,
+    TActual const& actual,
+    char const* expectedExpr,
+    char const* actualExpr,
+    char const* message = "")
+{
+  GTEST_ASSERT_AT_(
+      file,
+      line,
+      ::testing::internal::EqHelper::Compare(expectedExpr, actualExpr, expected, actual),
+      GTEST_FATAL_FAILURE_AT_)
+      << FormatCustomMsg(line, message);
+}
+
+template <
+    class TExpected,
+    class TActual,
+    std::enable_if_t<
+        std::is_same_v<TExpected, TActual> && !std::is_same_v<TExpected, WCHAR> && !std::is_same_v<TExpected, char>,
+        int> = 1>
+void AreEqualAt(
+    char const* file,
+    int line,
+    TExpected const* expected,
+    TActual const* actual,
+    char const* expectedExpr,
+    char const* actualExpr,
+    char const* message = "")
+{
+  GTEST_ASSERT_AT_(
+      file,
+      line,
+      ::testing::internal::EqHelper<GTEST_IS_NULL_LITERAL_(expected)>::Compare(
+          expectedExpr, actualExpr, expected, actual),
+      GTEST_FATAL_FAILURE_AT_)
+      << FormatCustomMsg(line, message);
+}
+
+inline void AreEqualAt(
+    char const* file,
+    int line,
+    WCHAR const* expected,
+    WCHAR const* actual,
+    char const* expectedExpr,
+    char const* actualExpr,
+    char const* message = "")
+{
+  GTEST_ASSERT_AT_(
+      file,
+      line,
+      ::testing::internal::CmpHelperSTREQ(expectedExpr, actualExpr, expected, actual),
+      GTEST_FATAL_FAILURE_AT_)
+      << FormatCustomMsg(line, message);
+}
+
+inline void AreEqualAt(
+    char const* file,
+    int line,
+    char const* expected,
+    char const* actual,
+    char const* expectedExpr,
+    char const* actualExpr,
+    char const* message = "")
+{
+  GTEST_ASSERT_AT_(
+      file,
+      line,
+      ::testing::internal::CmpHelperSTREQ(expectedExpr, actualExpr, expected, actual),
+      GTEST_FATAL_FAILURE_AT_)
+      << FormatCustomMsg(line, message);
+}
+
+inline void AreEqualAt(
+    char const* file,
+    int line,
+    WCHAR* expected,
+    WCHAR const* actual,
+    char const* expectedExpr,
+    char const* actualExpr,
+    char const* message = "")
+{
+  GTEST_ASSERT_AT_(
+      file,
+      line,
+      ::testing::internal::CmpHelperSTREQ(expectedExpr, actualExpr, expected, actual),
+      GTEST_FATAL_FAILURE_AT_)
+      << FormatCustomMsg(line, message);
+}
+
+inline void AreEqualAt(
+    char const* file,
+    int line,
+    char* expected,
+    const char* actual,
+    char const* expectedExpr,
+    char const* actualExpr,
+    const char* message = "")
+{
+  GTEST_ASSERT_AT_(
+      file,
+      line,
+      ::testing::internal::CmpHelperSTREQ(expectedExpr, actualExpr, expected, actual),
+      GTEST_FATAL_FAILURE_AT_)
+      << FormatCustomMsg(line, message);
+}
+
+// Code used for all the C++ exceptions
+constexpr uint32_t EXCEPTION_CPLUSPLUS = static_cast<uint32_t>(0xE06D7363);
+
+inline uint32_t FilterCrashExceptions(uint32_t exceptionCode) noexcept
+{
+  if ((exceptionCode == EXCEPTION_BREAKPOINT) // allow exceptions to get to the debugger
+      || (exceptionCode == EXCEPTION_SINGLE_STEP) // allow exceptions to get to the debugger
+      || (exceptionCode == EXCEPTION_GUARD_PAGE) // allow to crash on memory page access violation
+      || (exceptionCode == EXCEPTION_STACK_OVERFLOW)) // allow to crash on stack overflow
+  {
+    return EXCEPTION_CONTINUE_SEARCH;
+  }
+
+  if (exceptionCode == EXCEPTION_CPLUSPLUS) // log C++ exception and pass it through
+  {
+    FailAt(__FILE__, __LINE__, "Test function did not crash, but exception is thrown!");
+    return EXCEPTION_CONTINUE_SEARCH;
+  }
+
+  return EXCEPTION_EXECUTE_HANDLER;
+}
+
+template <class TLambda>
+inline bool ExpectCrashCore(TLambda const& lambda)
+{
+  __try
+  {
+    lambda();
+    return false;
+  }
+  __except (FilterCrashExceptions(GetExceptionCode()))
+  {
+    return true;
+  }
+}
+
+template <class TLambda>
+inline void
+ExpectCrashAt(char const* file, int line, TLambda const& lambda, char const* exprStr, char const* message = "")
+{
+  if (!ExpectCrashCore(lambda))
+  {
+    FailInternalAt(
+        file,
+        line,
+        message,
+        FormatMsg(
+            "Expected: [ %s ] must crash\n"
+            "  Actual: it does not crash\n",
+            exprStr));
+  }
+}
+
+struct TerminateHandlerRestorer
+{
+  ~TerminateHandlerRestorer() noexcept
+  {
+    std::set_terminate(Handler);
+  }
+
+  std::terminate_handler Handler;
+};
+
+BEGIN_DISABLE_WARNING_FUNCTION_MAY_NOT_CALL_DTOR()
+template <class TLambda>
+inline bool ExpectTerminateCore(TLambda const& lambda)
+{
+  static jmp_buf buf;
+
+  // Set a terminate handler and save the previous terminate handler to be restored in the end of function.
+  TerminateHandlerRestorer terminateRestore = {std::set_terminate([]() { longjmp(buf, 1); })};
+
+  // setjmp originally returns 0, and when longjmp is called it returns 1.
+  if (!setjmp(buf))
+  {
+    lambda();
+    return false; // must not be executed if fn() caused termination and the longjmp is executed.
+  }
+  else
+  {
+    return true; // executed if longjmp is executed in the terminate handler.
+  }
+}
+END_DISABLE_WARNING_FUNCTION_MAY_NOT_CALL_DTOR()
+
+template <class TLambda>
+inline void
+ExpectTerminateAt(char const* file, int line, TLambda const& lambda, char const* exprStr, char const* message = "")
+{
+  if (!ExpectTerminateCore(lambda))
+  {
+    FailInternalAt(
+        file,
+        line,
+        message,
+        FormatMsg(
+            "Expected: [ %s ] must terminate\n"
+            "  Actual: it does not terminate\n",
+            exprStr));
+  }
+}
+
+template <class TException, class TLambda>
+inline void ExpectExceptionAt(
+    char const* file,
+    int line,
+    TLambda const& lambda,
+    char const* exceptionStr,
+    char const* exprStr,
+    char const* message = "")
+{
+  char const* actualIssue = "";
+  bool isFailed = false;
+  bool isExpectedExceptionCaught = false;
+
+  try
+  {
+    lambda();
+  }
+  catch (TException const&)
+  {
+    isExpectedExceptionCaught = true;
+  }
+  catch (...)
+  {
+    isFailed = true;
+    actualIssue = "it throws a different type";
+  }
+
+  if (!isExpectedExceptionCaught && !isFailed)
+  {
+    isFailed = true;
+    actualIssue = "it does not throw";
+  }
+
+  if (isFailed)
+  {
+    FailInternalAt(
+        file,
+        line,
+        message,
+        FormatMsg(
+            "Expected: [ %s ] throws an exception of type %s\n"
+            "  Actual: %s\n",
+            exprStr,
+            exceptionStr,
+            actualIssue));
+  }
+}
+
+template <class TLambda>
+inline void
+ExpectNoThrowAt(char const* file, int line, TLambda const& lambda, char const* exprStr, char const* message = "")
+{
+  try
+  {
+    lambda();
+  }
+  catch (...)
+  {
+    FailInternalAt(
+        file,
+        line,
+        message,
+        FormatMsg(
+            "Expected: [ %s ] does not throw an exception\n"
+            "  Actual: it throws an exception\n",
+            exprStr));
+  }
+}
 
 // Asserts that the specified condition is true, if it is false the unit test will fail
 inline void IsTrue(bool condition, _In_z_ const WCHAR* message = L"")
@@ -62,14 +400,15 @@ template <
     typename ExpectedType,
     typename ActualType,
     typename TEnable = typename std::enable_if<
-        std::is_same<ExpectedType, ActualType>::value && !std::is_same<ExpectedType, wchar_t>::value
+        std::is_same<ExpectedType, ActualType>::value && !std::is_same<ExpectedType, WCHAR>::value
         && !std::is_same<ExpectedType, char>::value>::type>
 void AreEqual(_In_ const ExpectedType* expected, _In_ const ActualType* actual, _In_z_ const WCHAR* message = L"")
 {
-  AreEqual(*expected, *actual, message);
+  std::wstring wstrMessage(message);
+  ASSERT_EQ(expected, actual) << wstrMessage.c_str();
 }
 
-inline void AreEqual(_In_ const wchar_t* expected, _In_ const wchar_t* actual, _In_z_ const WCHAR* message = L"")
+inline void AreEqual(_In_ const WCHAR* expected, _In_ const WCHAR* actual, _In_z_ const WCHAR* message = L"")
 {
   std::wstring wstrMessage(message);
   ASSERT_STREQ(expected, actual) << wstrMessage.c_str();
@@ -81,7 +420,7 @@ inline void AreEqual(_In_ const char* expected, _In_ const char* actual, _In_z_ 
   ASSERT_STREQ(expected, actual) << wstrMessage.c_str();
 }
 
-inline void AreEqual(_In_ wchar_t* expected, _In_ const wchar_t* actual, _In_z_ const WCHAR* message = L"")
+inline void AreEqual(_In_ WCHAR* expected, _In_ const WCHAR* actual, _In_z_ const WCHAR* message = L"")
 {
   std::wstring wstrMessage(message);
   ASSERT_STREQ(expected, actual) << wstrMessage.c_str();
@@ -105,14 +444,14 @@ template <
     typename ExpectedType,
     typename ActualType,
     typename TEnable = typename std::enable_if<
-        std::is_same<ExpectedType, ActualType>::value && !std::is_same<ExpectedType, wchar_t>::value
+        std::is_same<ExpectedType, ActualType>::value && !std::is_same<ExpectedType, WCHAR>::value
         && !std::is_same<ExpectedType, char>::value>::type>
 void AreNotEqual(_In_ const ExpectedType* expected, _In_ const ActualType* actual, _In_z_ const WCHAR* message = L"")
 {
   AreNotEqual(*expected, *actual, message);
 }
 
-inline void AreNotEqual(_In_ const wchar_t* expected, _In_ const wchar_t* actual, _In_z_ const WCHAR* message = L"")
+inline void AreNotEqual(_In_ const WCHAR* expected, _In_ const WCHAR* actual, _In_z_ const WCHAR* message = L"")
 {
   std::wstring wstrMessage(message);
   ASSERT_STRNE(expected, actual) << wstrMessage.c_str();
@@ -124,7 +463,7 @@ inline void AreNotEqual(_In_ const char* expected, _In_ const char* actual, _In_
   ASSERT_STRNE(expected, actual) << wstrMessage.c_str();
 }
 
-inline void AreNotEqual(_In_ wchar_t* expected, _In_ const wchar_t* actual, _In_z_ const WCHAR* message = L"")
+inline void AreNotEqual(_In_ WCHAR* expected, _In_ const WCHAR* actual, _In_z_ const WCHAR* message = L"")
 {
   std::wstring wstrMessage(message);
   ASSERT_STRNE(expected, actual) << wstrMessage.c_str();
@@ -189,7 +528,7 @@ inline void ExpectException(const std::function<void()>& statement, const WCHAR*
 template <typename ExceptionType>
 inline void ExpectException(
     const std::function<void()>& statement,
-    const std::function<void()>& /*onException*/,
+    const std::function<void()>& onException,
     const WCHAR* message = L"")
 {
   EXPECT_THROW(statement(), ExceptionType) << message;
@@ -210,106 +549,15 @@ inline void HrFailed(HRESULT hr, _In_z_ const WCHAR* message = L"")
   ASSERT_FALSE(SUCCEEDED(hr)) << message;
 }
 
-#ifdef MS_TARGET_WINDOWS
-// Code used for all the C++ exceptions
-static const DWORD EXCEPTION_CPLUSPLUS = static_cast<DWORD>(0xE06D7363);
-
-inline DWORD FilterCrashExceptions(DWORD exceptionCode) noexcept
-{
-  if ((exceptionCode == EXCEPTION_BREAKPOINT) // allow exceptions to get to the debugger
-      || (exceptionCode == EXCEPTION_SINGLE_STEP) // allow exceptions to get to the debugger
-      || (exceptionCode == EXCEPTION_GUARD_PAGE) // allow to crash on memory page access violation
-      || (exceptionCode == EXCEPTION_STACK_OVERFLOW)) // allow to crash on stack overflow
-  {
-    return EXCEPTION_CONTINUE_SEARCH;
-  }
-  if (exceptionCode == EXCEPTION_CPLUSPLUS) // log C++ exception and pass it through
-  {
-    TestAssert::Fail(L"Test function did not crash, but exception is thrown!");
-    return EXCEPTION_CONTINUE_SEARCH;
-  }
-  return EXCEPTION_EXECUTE_HANDLER;
-}
-
-BEGIN_DISABLE_WARNING_UNREACHABLE_CODE()
-template <typename Fn>
-inline bool ExpectCrashCore(const Fn& fn, const WCHAR* /*message*/)
-{
-  __try
-  {
-    fn();
-  }
-  __except (FilterCrashExceptions(GetExceptionCode()))
-  {
-    // Pass(message == nullptr || message[0] == L'\0' ? L"Crash occurred as expected." : message);
-    return true;
-  }
-  // Fail(message == nullptr || message[0] == L'\0' ? L"Test function did not crash!" : message);
-  return false;
-}
-END_DISABLE_WARNING_UNREACHABLE_CODE()
-
-#else
-
-using SigAction = void (*)(int, siginfo_t*, void*);
-
-// An RAII class that sets custom action for segmentation fault signal and
-// restores the old one in the destructor.
-struct CrashState
-{
-  CrashState(SigAction action) noexcept
-  {
-    sigemptyset(&m_action.sa_mask);
-    m_action.sa_sigaction = action;
-    m_action.sa_flags = SA_NODEFER;
-    sigaction(SIGSEGV, &m_action, &m_oldAction);
-  }
-
-  ~CrashState() noexcept
-  {
-    sigaction(SIGSEGV, &m_oldAction, nullptr);
-  }
-
-private:
-  struct sigaction m_action
-  {
-  };
-  struct sigaction m_oldAction
-  {
-  };
-};
-
-// Returns true if crash (segmentation fault happened)
-template <class Fn>
-inline bool ExpectCrashCore(const Fn& fn, const WCHAR* /*message*/)
-{
-  static sigjmp_buf buf{};
-
-  // Set sigaction and save the previous action to be restored in the end of
-  // function.
-  CrashState crashState{[](int /*signal*/, siginfo_t* /*si*/, void* /*arg*/) { longjmp(buf, 1); }};
-
-  // setjmp originally returns 0, and when longjmp is called it returns 1.
-  if (!setjmp(buf))
-  {
-    fn();
-    return true; // must not be executed if fn() caused crash and the longjmp is executed.
-  }
-  else
-  {
-    return true; // executed if longjmp is executed in the SigAction handler.
-  }
-}
-
-#endif
-
 template <typename Fn>
 inline void ExpectVEC(const Fn& fn, const WCHAR* message = L"")
 {
-  if (!ExpectCrashCore(fn, message))
+  if (!ExpectCrashCore(fn))
   {
     Fail(message);
   }
 }
 
 } // namespace TestAssert
+
+#endif // MSO_MOTIFCPP_MOTIFCPPTEST_H

--- a/libs/motifCpp/include/motifCpp/motifCppTestBase.h
+++ b/libs/motifCpp/include/motifCpp/motifCppTestBase.h
@@ -2,6 +2,8 @@
 // Licensed under the MIT license.
 
 #pragma once
+#ifndef MSO_MOTIFCPP_MOTIFCPPTESTBASE_H
+#define MSO_MOTIFCPP_MOTIFCPPTESTBASE_H
 
 typedef wchar_t WCHAR;
 
@@ -23,3 +25,5 @@ public:
 
   virtual void Teardown() {}
 };
+
+#endif // MSO_MOTIFCPP_MOTIFCPPTESTBASE_H

--- a/libs/motifCpp/include/motifCpp/testCheck.h
+++ b/libs/motifCpp/include/motifCpp/testCheck.h
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 #pragma once
-#ifndef MSO_MOTIFCPP_TESTCHECK_H
-#define MSO_MOTIFCPP_TESTCHECK_H
+#ifndef TEST_TESTCHECK_H
+#define TEST_TESTCHECK_H
 
 //=============================================================================
 // Test macros for better error reporting.
@@ -16,39 +16,49 @@
 // use the macros we provide.
 //=============================================================================
 
-#include "motifCpp/assert_motifApi.h"
+#include <compilerAdapters/compilerWarnings.h>
+#include <motifCpp/assert_motifApi.h>
+#include <csetjmp>
+#include <csignal>
+
+//=============================================================================
+// A helper macro to provide current line number as a wide char string.
+//=============================================================================
+#ifndef MSO_TO_STR
+#define MSO_INTERNAL_TO_STR(value) #value
+#define MSO_TO_STR(value) MSO_INTERNAL_TO_STR(value)
+#endif
+
+#ifndef MSO_WIDE_STR
+#define MSO_INTERNAL_WIDE_STR(str) L##str
+#define MSO_WIDE_STR(str) MSO_INTERNAL_WIDE_STR(str)
+#endif
+
+#define MSO_LINE_STR MSO_TO_STR(__LINE__)
+#define MSO_LINE_WIDE_STR MSO_WIDE_STR(MSO_LINE_STR)
 
 //=============================================================================
 // TestCheckFail fails the test unconditionally.
 //=============================================================================
-#define TestCheckFailAt(file, line, ...) TestAssert::FailAt(file, line, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
-#define TestCheckFail(...) TestCheckFailAt(__FILE__, __LINE__, __VA_ARGS__)
+#define TestCheckFailL(message, line) TestAssert::Fail(MSO_WIDE_STR("Line: " line " " message))
+#define TestCheckFail(message) TestCheckFailL(message, MSO_LINE_STR)
 
 //=============================================================================
 // TestCheck checks if provided expression evaluates to true.
 // If check fails then it reports the line number and the failed expression.
-//
-// Note that we convert expression to string before we pass it to an
-// Internal macro. This is for better message in case if expression is a macro.
-// It will be shown as macro usage rather than macro being expanded.
 //=============================================================================
-#define TestCheckAtInternal(file, line, expr, exprStr, ...) \
-  TestAssert::IsTrueAt(file, line, expr, exprStr, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
-#define TestCheckAt(file, line, expr, ...) TestCheckAtInternal(file, line, expr, #expr, __VA_ARGS__)
-#define TestCheck(expr, ...) TestCheckAtInternal(__FILE__, __LINE__, expr, #expr, __VA_ARGS__)
+#define TestCheckL(expr, line) TestAssert::IsTrue(expr, MSO_WIDE_STR("Line: " line " [ " MSO_TO_STR(expr) " ]"))
+#define TestCheck(expr) TestCheckL(expr, MSO_LINE_STR)
 
 //=============================================================================
 // TestCheckEqual checks if two provided values are equal.
 // If check fails then it reports the line number and the failed expression.
 // In addition the TestAssert::AreEqual reports expected and actual values.
 //=============================================================================
-#define TestCheckEqualAtInternal(file, line, expected, actual, expectedStr, actualStr, ...) \
-  TestAssert::AreEqualAt(                                                                   \
-      file, line, expected, actual, expectedStr, actualStr, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
-#define TestCheckEqualAt(file, line, expected, actual, ...) \
-  TestCheckEqualAtInternal(file, line, expected, actual, #expected, #actual, __VA_ARGS__)
-#define TestCheckEqual(expected, actual, ...) \
-  TestCheckEqualAtInternal(__FILE__, __LINE__, expected, actual, #expected, #actual, __VA_ARGS__)
+#define TestCheckEqualL(expected, actual, line) \
+  TestAssert::AreEqual(                         \
+      expected, actual, MSO_WIDE_STR("Line: " line " [ " MSO_TO_STR(expected) " == " MSO_TO_STR(actual) " ]"))
+#define TestCheckEqual(expected, actual) TestCheckEqualL(expected, actual, MSO_LINE_STR)
 
 //=============================================================================
 // TestCheckIgnore ignores the provided expression.
@@ -60,11 +70,15 @@
 //=============================================================================
 // TestCheckCrash expects that the provided expression causes a crash.
 //=============================================================================
-#define TestCheckCrashAtInternal(file, line, expr, exprStr, ...) \
-  TestAssert::ExpectCrashAt(                                     \
-      file, line, [&]() { expr; }, exprStr, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
-#define TestCheckCrashAt(file, line, expr, ...) TestCheckCrashAtInternal(file, line, expr, #expr, __VA_ARGS__)
-#define TestCheckCrash(expr, ...) TestCheckCrashAtInternal(__FILE__, __LINE__, expr, #expr, __VA_ARGS__)
+//	Mso::IgnoreAllAsserts ignore;
+#define TestCheckCrashL(expr, line) \
+  TestAssert::ExpectVEC(            \
+      [&]() {                       \
+        OACR_POSSIBLE_THROW;        \
+        expr;                       \
+      },                            \
+      MSO_WIDE_STR("Line: " line " Must crash: [ " MSO_TO_STR(expr) " ]"))
+#define TestCheckCrash(expr) TestCheckCrashL(expr, MSO_LINE_STR)
 
 //=============================================================================
 // TestCheckTerminate expects that the provided expression causes process termination
@@ -75,39 +89,24 @@
 // the call stack is not unwinded correctly.
 // You should disable memory leak detection in tests that use TestCheckTerminate.
 //=============================================================================
-#define TestCheckTerminateAtInternal(file, line, expr, exprStr, ...) \
-  TestAssert::ExpectTerminateAt(                                     \
-      file, line, [&]() { expr; }, exprStr, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
-#define TestCheckTerminateAt(file, line, expr, ...) TestCheckTerminateAtInternal(file, line, expr, #expr, __VA_ARGS__)
-#define TestCheckTerminate(expr, ...) TestCheckTerminateAtInternal(__FILE__, __LINE__, expr, #expr, __VA_ARGS__)
+#define TestCheckTerminateL(expr, line) \
+  TestAssert::ExpectTerminate([&]() { expr; }, MSO_WIDE_STR("Line: " line " Must terminate: [ " MSO_TO_STR(expr) " ]"))
+#define TestCheckTerminate(expr) TestCheckTerminateL(expr, MSO_LINE_STR)
 
 //=============================================================================
 // TestCheckException expects that the provided expression throws an exception.
 //=============================================================================
-#define TestCheckExceptionAtInternal(file, line, ex, expr, exStr, exprStr, ...) \
-  TestAssert::ExpectExceptionAt<ex>(                                            \
-      file,                                                                     \
-      line,                                                                     \
-      [&]() {                                                                   \
-        OACR_POSSIBLE_THROW;                                                    \
-        expr;                                                                   \
-      },                                                                        \
-      exStr,                                                                    \
-      exprStr,                                                                  \
-      TestAssert::FormatMsg("" __VA_ARGS__).c_str())
-#define TestCheckExceptionAt(file, line, ex, expr, ...) \
-  TestCheckExceptionAtInternal(file, line, ex, expr, #ex, #expr, __VA_ARGS__)
-#define TestCheckException(ex, expr, ...) \
-  TestCheckExceptionAtInternal(__FILE__, __LINE__, ex, expr, #ex, #expr, __VA_ARGS__)
+#define TestCheckExceptionL(ex, expr, line) \
+  TestAssert::ExpectException<ex>(          \
+      [&]() { expr; }, MSO_WIDE_STR("Line: " line " Must throw: " MSO_TO_STR(ex) " [ " MSO_TO_STR(expr) " ]"))
+#define TestCheckException(ex, expr) TestCheckExceptionL(ex, expr, MSO_LINE_STR)
 
 //=============================================================================
 // TestCheckNoThrow expects that the provided expression does not throw an exception.
 //=============================================================================
-#define TestCheckNoThrowAtInternal(file, line, expr, exprStr, ...) \
-  TestAssert::ExpectNoThrowAt(                                     \
-      file, line, [&]() { expr; }, exprStr, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
-#define TestCheckNoThrowAt(file, line, expr, ...) TestCheckNoThrowAtInternal(file, line, expr, #expr, __VA_ARGS__)
-#define TestCheckNoThrow(expr, ...) TestCheckNoThrowAtInternal(__FILE__, __LINE__, expr, #expr, __VA_ARGS__)
+#define TestCheckNoThrowL(expr, line) \
+  TestAssert::ExpectNoThrow([&]() { expr; }, MSO_WIDE_STR("Line: " line " Must not throw: [ " MSO_TO_STR(expr) " ]"))
+#define TestCheckNoThrow(expr) TestCheckNoThrowL(expr, MSO_LINE_STR)
 
 //=============================================================================
 // TestCheckAssert checks for the code to produce assert with specified tag.
@@ -123,10 +122,55 @@
 // MemoryLeakDetectionHook::TrackPerTest m_trackLeakPerTest;
 //=============================================================================
 #define TEST_DISABLE_MEMORY_LEAK_DETECTION() \
-  //StopTrackingMemoryAllocations(); \
-	//auto restartTrackingMemoryAllocations = Mso::TCleanup::Make([&]() noexcept \
-	//{ \
-	//	StartTrackingMemoryAllocations(); \
-	//});
+  StopTrackingMemoryAllocations();           \
+  auto restartTrackingMemoryAllocations = Mso::TCleanup::Make([&]() noexcept { StartTrackingMemoryAllocations(); });
 
-#endif // MSO_MOTIFCPP_TESTCHECK_H
+//=============================================================================
+// Helper functions to implement TestCheckTerminate.
+//=============================================================================
+namespace TestAssert {
+
+struct TerminateHandlerRestorer
+{
+  ~TerminateHandlerRestorer() noexcept
+  {
+    std::set_terminate(Handler);
+  }
+
+  std::terminate_handler Handler;
+};
+
+BEGIN_DISABLE_WARNING_FUNCTION_MAY_NOT_CALL_DTOR()
+template <class Fn>
+inline bool ExpectTerminateCore(const Fn& fn)
+{
+  static jmp_buf buf;
+
+  // Set a terminate handler and save the previous terminate handler to be restored in the end of function.
+  TerminateHandlerRestorer terminateRestore = {std::set_terminate([]() { longjmp(buf, 1); })};
+
+  // setjmp originally returns 0, and when longjmp is called it returns 1.
+  if (!setjmp(buf))
+  {
+    fn();
+    return false; // must not be executed if fn() caused termination and the longjmp is executed.
+  }
+  else
+  {
+    return true; // executed if longjmp is executed in the terminate handler.
+  }
+}
+END_DISABLE_WARNING_FUNCTION_MAY_NOT_CALL_DTOR()
+
+template <class Fn>
+inline void ExpectTerminate(const Fn& fn, const WCHAR* message = L"")
+{
+  if (!ExpectTerminateCore(fn))
+  {
+    Fail(message == nullptr || message[0] == L'\0' ? L"Test function did not terminate!" : message);
+  }
+}
+
+} // namespace TestAssert
+
+#endif // TEST_TESTCHECK_H

--- a/libs/motifCpp/include/motifCpp/testCheck.h
+++ b/libs/motifCpp/include/motifCpp/testCheck.h
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 #pragma once
-#ifndef TEST_TESTCHECK_H
-#define TEST_TESTCHECK_H
+#ifndef MSO_MOTIFCPP_TESTCHECK_H
+#define MSO_MOTIFCPP_TESTCHECK_H
 
 //=============================================================================
 // Test macros for better error reporting.
@@ -16,49 +16,39 @@
 // use the macros we provide.
 //=============================================================================
 
-#include <compilerAdapters/compilerWarnings.h>
-#include <motifCpp/assert_motifApi.h>
-#include <csetjmp>
-#include <csignal>
-
-//=============================================================================
-// A helper macro to provide current line number as a wide char string.
-//=============================================================================
-#ifndef MSO_TO_STR
-#define MSO_INTERNAL_TO_STR(value) #value
-#define MSO_TO_STR(value) MSO_INTERNAL_TO_STR(value)
-#endif
-
-#ifndef MSO_WIDE_STR
-#define MSO_INTERNAL_WIDE_STR(str) L##str
-#define MSO_WIDE_STR(str) MSO_INTERNAL_WIDE_STR(str)
-#endif
-
-#define MSO_LINE_STR MSO_TO_STR(__LINE__)
-#define MSO_LINE_WIDE_STR MSO_WIDE_STR(MSO_LINE_STR)
+#include "motifCpp/assert_motifApi.h"
 
 //=============================================================================
 // TestCheckFail fails the test unconditionally.
 //=============================================================================
-#define TestCheckFailL(message, line) TestAssert::Fail(MSO_WIDE_STR("Line: " line " " message))
-#define TestCheckFail(message) TestCheckFailL(message, MSO_LINE_STR)
+#define TestCheckFailAt(file, line, ...) TestAssert::FailAt(file, line, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
+#define TestCheckFail(...) TestCheckFailAt(__FILE__, __LINE__, __VA_ARGS__)
 
 //=============================================================================
 // TestCheck checks if provided expression evaluates to true.
 // If check fails then it reports the line number and the failed expression.
+//
+// Note that we convert expression to string before we pass it to an
+// Internal macro. This is for better message in case if expression is a macro.
+// It will be shown as macro usage rather than macro being expanded.
 //=============================================================================
-#define TestCheckL(expr, line) TestAssert::IsTrue(expr, MSO_WIDE_STR("Line: " line " [ " MSO_TO_STR(expr) " ]"))
-#define TestCheck(expr) TestCheckL(expr, MSO_LINE_STR)
+#define TestCheckAtInternal(file, line, expr, exprStr, ...) \
+  TestAssert::IsTrueAt(file, line, expr, exprStr, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
+#define TestCheckAt(file, line, expr, ...) TestCheckAtInternal(file, line, expr, #expr, __VA_ARGS__)
+#define TestCheck(expr, ...) TestCheckAtInternal(__FILE__, __LINE__, expr, #expr, __VA_ARGS__)
 
 //=============================================================================
 // TestCheckEqual checks if two provided values are equal.
 // If check fails then it reports the line number and the failed expression.
 // In addition the TestAssert::AreEqual reports expected and actual values.
 //=============================================================================
-#define TestCheckEqualL(expected, actual, line) \
-  TestAssert::AreEqual(                         \
-      expected, actual, MSO_WIDE_STR("Line: " line " [ " MSO_TO_STR(expected) " == " MSO_TO_STR(actual) " ]"))
-#define TestCheckEqual(expected, actual) TestCheckEqualL(expected, actual, MSO_LINE_STR)
+#define TestCheckEqualAtInternal(file, line, expected, actual, expectedStr, actualStr, ...) \
+  TestAssert::AreEqualAt(                                                                   \
+      file, line, expected, actual, expectedStr, actualStr, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
+#define TestCheckEqualAt(file, line, expected, actual, ...) \
+  TestCheckEqualAtInternal(file, line, expected, actual, #expected, #actual, __VA_ARGS__)
+#define TestCheckEqual(expected, actual, ...) \
+  TestCheckEqualAtInternal(__FILE__, __LINE__, expected, actual, #expected, #actual, __VA_ARGS__)
 
 //=============================================================================
 // TestCheckIgnore ignores the provided expression.
@@ -70,15 +60,11 @@
 //=============================================================================
 // TestCheckCrash expects that the provided expression causes a crash.
 //=============================================================================
-//	Mso::IgnoreAllAsserts ignore;
-#define TestCheckCrashL(expr, line) \
-  TestAssert::ExpectVEC(            \
-      [&]() {                       \
-        OACR_POSSIBLE_THROW;        \
-        expr;                       \
-      },                            \
-      MSO_WIDE_STR("Line: " line " Must crash: [ " MSO_TO_STR(expr) " ]"))
-#define TestCheckCrash(expr) TestCheckCrashL(expr, MSO_LINE_STR)
+#define TestCheckCrashAtInternal(file, line, expr, exprStr, ...) \
+  TestAssert::ExpectCrashAt(                                     \
+      file, line, [&]() { expr; }, exprStr, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
+#define TestCheckCrashAt(file, line, expr, ...) TestCheckCrashAtInternal(file, line, expr, #expr, __VA_ARGS__)
+#define TestCheckCrash(expr, ...) TestCheckCrashAtInternal(__FILE__, __LINE__, expr, #expr, __VA_ARGS__)
 
 //=============================================================================
 // TestCheckTerminate expects that the provided expression causes process termination
@@ -89,24 +75,39 @@
 // the call stack is not unwinded correctly.
 // You should disable memory leak detection in tests that use TestCheckTerminate.
 //=============================================================================
-#define TestCheckTerminateL(expr, line) \
-  TestAssert::ExpectTerminate([&]() { expr; }, MSO_WIDE_STR("Line: " line " Must terminate: [ " MSO_TO_STR(expr) " ]"))
-#define TestCheckTerminate(expr) TestCheckTerminateL(expr, MSO_LINE_STR)
+#define TestCheckTerminateAtInternal(file, line, expr, exprStr, ...) \
+  TestAssert::ExpectTerminateAt(                                     \
+      file, line, [&]() { expr; }, exprStr, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
+#define TestCheckTerminateAt(file, line, expr, ...) TestCheckTerminateAtInternal(file, line, expr, #expr, __VA_ARGS__)
+#define TestCheckTerminate(expr, ...) TestCheckTerminateAtInternal(__FILE__, __LINE__, expr, #expr, __VA_ARGS__)
 
 //=============================================================================
 // TestCheckException expects that the provided expression throws an exception.
 //=============================================================================
-#define TestCheckExceptionL(ex, expr, line) \
-  TestAssert::ExpectException<ex>(          \
-      [&]() { expr; }, MSO_WIDE_STR("Line: " line " Must throw: " MSO_TO_STR(ex) " [ " MSO_TO_STR(expr) " ]"))
-#define TestCheckException(ex, expr) TestCheckExceptionL(ex, expr, MSO_LINE_STR)
+#define TestCheckExceptionAtInternal(file, line, ex, expr, exStr, exprStr, ...) \
+  TestAssert::ExpectExceptionAt<ex>(                                            \
+      file,                                                                     \
+      line,                                                                     \
+      [&]() {                                                                   \
+        OACR_POSSIBLE_THROW;                                                    \
+        expr;                                                                   \
+      },                                                                        \
+      exStr,                                                                    \
+      exprStr,                                                                  \
+      TestAssert::FormatMsg("" __VA_ARGS__).c_str())
+#define TestCheckExceptionAt(file, line, ex, expr, ...) \
+  TestCheckExceptionAtInternal(file, line, ex, expr, #ex, #expr, __VA_ARGS__)
+#define TestCheckException(ex, expr, ...) \
+  TestCheckExceptionAtInternal(__FILE__, __LINE__, ex, expr, #ex, #expr, __VA_ARGS__)
 
 //=============================================================================
 // TestCheckNoThrow expects that the provided expression does not throw an exception.
 //=============================================================================
-#define TestCheckNoThrowL(expr, line) \
-  TestAssert::ExpectNoThrow([&]() { expr; }, MSO_WIDE_STR("Line: " line " Must not throw: [ " MSO_TO_STR(expr) " ]"))
-#define TestCheckNoThrow(expr) TestCheckNoThrowL(expr, MSO_LINE_STR)
+#define TestCheckNoThrowAtInternal(file, line, expr, exprStr, ...) \
+  TestAssert::ExpectNoThrowAt(                                     \
+      file, line, [&]() { expr; }, exprStr, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
+#define TestCheckNoThrowAt(file, line, expr, ...) TestCheckNoThrowAtInternal(file, line, expr, #expr, __VA_ARGS__)
+#define TestCheckNoThrow(expr, ...) TestCheckNoThrowAtInternal(__FILE__, __LINE__, expr, #expr, __VA_ARGS__)
 
 //=============================================================================
 // TestCheckAssert checks for the code to produce assert with specified tag.
@@ -122,55 +123,10 @@
 // MemoryLeakDetectionHook::TrackPerTest m_trackLeakPerTest;
 //=============================================================================
 #define TEST_DISABLE_MEMORY_LEAK_DETECTION() \
-  StopTrackingMemoryAllocations();           \
-  auto restartTrackingMemoryAllocations = Mso::TCleanup::Make([&]() noexcept { StartTrackingMemoryAllocations(); });
+  //StopTrackingMemoryAllocations(); \
+	//auto restartTrackingMemoryAllocations = Mso::TCleanup::Make([&]() noexcept \
+	//{ \
+	//	StartTrackingMemoryAllocations(); \
+	//});
 
-//=============================================================================
-// Helper functions to implement TestCheckTerminate.
-//=============================================================================
-namespace TestAssert {
-
-struct TerminateHandlerRestorer
-{
-  ~TerminateHandlerRestorer() noexcept
-  {
-    std::set_terminate(Handler);
-  }
-
-  std::terminate_handler Handler;
-};
-
-BEGIN_DISABLE_WARNING_FUNCTION_MAY_NOT_CALL_DTOR()
-template <class Fn>
-inline bool ExpectTerminateCore(const Fn& fn)
-{
-  static jmp_buf buf;
-
-  // Set a terminate handler and save the previous terminate handler to be restored in the end of function.
-  TerminateHandlerRestorer terminateRestore = {std::set_terminate([]() { longjmp(buf, 1); })};
-
-  // setjmp originally returns 0, and when longjmp is called it returns 1.
-  if (!setjmp(buf))
-  {
-    fn();
-    return false; // must not be executed if fn() caused termination and the longjmp is executed.
-  }
-  else
-  {
-    return true; // executed if longjmp is executed in the terminate handler.
-  }
-}
-END_DISABLE_WARNING_FUNCTION_MAY_NOT_CALL_DTOR()
-
-template <class Fn>
-inline void ExpectTerminate(const Fn& fn, const WCHAR* message = L"")
-{
-  if (!ExpectTerminateCore(fn))
-  {
-    Fail(message == nullptr || message[0] == L'\0' ? L"Test function did not terminate!" : message);
-  }
-}
-
-} // namespace TestAssert
-
-#endif // TEST_TESTCHECK_H
+#endif // MSO_MOTIFCPP_TESTCHECK_H

--- a/libs/motifCpp/include/motifCpp/testInfo.h
+++ b/libs/motifCpp/include/motifCpp/testInfo.h
@@ -44,8 +44,6 @@
   };                                                                                                                  \
   virtual void methodName()
 
-#define TESTMETHOD_REQUIRES_SEH(methodName) TEST_METHOD(methodName)
-
 #define TestClassComponent(x1, x2)
 
 // Allows a test to be compiled, but not executed

--- a/libs/motifCpp/include/motifCpp/testInfo.h
+++ b/libs/motifCpp/include/motifCpp/testInfo.h
@@ -2,13 +2,12 @@
 // Licensed under the MIT license.
 
 #pragma once
-
-#ifndef TESTINFO_H
-#define TESTINFO_H
+#ifndef MSO_MOTIFCPP_TESTINFO_H
+#define MSO_MOTIFCPP_TESTINFO_H
 
 #include <memory>
 #include <vector>
-#include <motifCpp/motifCppTestBase.h>
+#include "motifCpp/motifCppTestBase.h"
 
 #define TEST_CLASS(className)                                                                      \
   struct className;                                                                                \
@@ -19,6 +18,18 @@
     TestClassInfo_##className() noexcept : TestClassInfoRegType{#className, __FILE__, __LINE__} {} \
   };                                                                                               \
                                                                                                    \
+  struct className : Mso::UnitTests::Internal::TestClassBase<className, TestClassInfo_##className>
+
+#define TEST_CLASS_EX(className, baseClass)                                                                     \
+  struct className;                                                                                             \
+                                                                                                                \
+  struct TestClassInfo_##className final                                                                        \
+      : baseClass                                                                                               \
+      , Mso::UnitTests::Internal::TestClassInfoReg<TestClassInfo_##className, className>                        \
+  {                                                                                                             \
+    TestClassInfo_##className() noexcept : baseClass{}, TestClassInfoRegType{#className, __FILE__, __LINE__} {} \
+  };                                                                                                            \
+                                                                                                                \
   struct className : Mso::UnitTests::Internal::TestClassBase<className, TestClassInfo_##className>
 
 #define TEST_METHOD(methodName)                                                                                       \
@@ -33,12 +44,14 @@
   };                                                                                                                  \
   virtual void methodName()
 
+#define TESTMETHOD_REQUIRES_SEH(methodName) TEST_METHOD(methodName)
+
 #define TestClassComponent(x1, x2)
 
 // Allows a test to be compiled, but not executed
 #define SKIPTESTMETHOD(methodName) virtual void skipped_##methodName()
 
-namespace Mso { namespace UnitTests {
+namespace Mso::UnitTests {
 
 using TestClass = MotifCppTestBase;
 struct TestClassInfo;
@@ -127,9 +140,9 @@ private:
   int m_sourceLine{0};
 };
 
-}} // namespace Mso::UnitTests
+} // namespace Mso::UnitTests
 
-namespace Mso { namespace UnitTests { namespace Internal {
+namespace Mso::UnitTests::Internal {
 
 template <class TTestClass, class TTestClassInfo>
 struct TestClassBase : TestClass
@@ -172,6 +185,6 @@ struct TestMethodInfoReg : TestMethodInfo
 template <class TMethodInfo>
 TMethodInfo TestMethodInfoReg<TMethodInfo>::Instance;
 
-}}} // namespace Mso::UnitTests::Internal
+} // namespace Mso::UnitTests::Internal
 
-#endif // TESTINFO_H
+#endif // MSO_MOTIFCPP_TESTINFO_H

--- a/libs/motifCpp/tests/CMakeLists.txt
+++ b/libs/motifCpp/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-liblet(typeTraits
-  DEPENDS
-    Mso::compilerAdapters
+liblet_tests(
+  SOURCES
+    motifCppTest.cpp
 )

--- a/libs/motifCpp/tests/motifCppTest.cpp
+++ b/libs/motifCpp/tests/motifCppTest.cpp
@@ -1,0 +1,224 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "crash/verifyElseCrash.h"
+#include "motifCpp/testCheck.h"
+
+// Uncomment to see errors
+//#define MOTIF_TEST_SHOW_ERRORS
+
+TEST_CLASS (MotifCppTest)
+{
+#ifdef MOTIF_TEST_SHOW_ERRORS
+
+  TEST_METHOD(GTestFailCalled)
+  {
+    FAIL();
+  }
+
+  TEST_METHOD(GTestFailCalledWithMessage)
+  {
+    FAIL() << "Test must fail";
+  }
+
+  TEST_METHOD(GTestFailCalledWithMessageArgs)
+  {
+    FAIL() << TestAssert::FormatMsg("Test %s %s %d", "must", "fail", 2);
+  }
+
+  TEST_METHOD(GTestAssertTrueFailed)
+  {
+    ASSERT_TRUE(std::string("Foo") == "Bar");
+  }
+
+  TEST_METHOD(GTestAssertTrueFailedWithMessage)
+  {
+    ASSERT_TRUE(std::string("Foo") == "Bar") << "Test must fail";
+  }
+
+  TEST_METHOD(GTestAssertTrueFailedWithMessageArgs)
+  {
+    ASSERT_TRUE(std::string("Foo") == "Bar") << TestAssert::FormatMsg("Test %s %s %d", "must", "fail", 2);
+  }
+
+  TEST_METHOD(GTestAssertEQFailed)
+  {
+    ASSERT_EQ(std::string("Foo"), "Bar");
+  }
+
+  TEST_METHOD(GTestAssertEQFailedWithMessage)
+  {
+    ASSERT_EQ(std::string("Foo"), "Bar") << "Test must fail";
+  }
+
+  TEST_METHOD(GTestAssertEQFailedWithMessageArgs)
+  {
+    ASSERT_EQ(std::string("Foo"), "Bar") << TestAssert::FormatMsg("Test %s %s %d", "must", "fail", 2);
+  }
+
+  TEST_METHOD(TestCheckFailCalled)
+  {
+    TestCheckFail();
+  }
+
+  TEST_METHOD(TestCheckFailCalledWithMessage)
+  {
+    TestCheckFail("Test must fail");
+  }
+
+  TEST_METHOD(TestCheckFailCalledWithMessageArgs)
+  {
+    TestCheckFail("Test %s %s %d", "must", "fail", 2);
+  }
+
+  TEST_METHOD(TestCheckFailed)
+  {
+    TestCheck(std::string("Foo") == "Bar");
+  }
+
+  TEST_METHOD(TestCheckFailedWithMessage)
+  {
+    TestCheck(std::string("Foo") == "Bar", "Test must fail");
+  }
+
+  TEST_METHOD(TestCheckFailedWithMessageArgs)
+  {
+    TestCheck(std::string("Foo") == "Bar", "Test %s %s %d", "must", "fail", 2);
+  }
+
+  TEST_METHOD(TestCheckEqualFailed)
+  {
+    TestCheckEqual(std::string("Foo"), "Bar");
+  }
+
+  TEST_METHOD(TestCheckEqualFailedWithMessage)
+  {
+    TestCheckEqual(std::string("Foo"), "Bar", "Test must fail");
+  }
+
+  TEST_METHOD(TestCheckEqualFailedWithMessageArgs)
+  {
+    TestCheckEqual(std::string("Foo"), "Bar", "Test %s %s %d", "must", "fail", 2);
+  }
+
+  TEST_METHOD(TestCheckCrashFailed)
+  {
+    TestCheckCrash(VerifyElseCrashSz(true, "No crash"));
+  }
+
+  TEST_METHOD(TestCheckCrashFailedWithMessage)
+  {
+    TestCheckCrash(VerifyElseCrashSz(true, "No crash"), "Test must fail");
+  }
+
+  TEST_METHOD(TestCheckCrashFailedWithMessageArgs)
+  {
+    TestCheckCrash(VerifyElseCrashSz(true, "No crash"), "Test %s %s %d", "must", "fail", 2);
+  }
+
+  TEST_METHOD(TestCheckCrashSucceeded)
+  {
+    TestCheckCrash(VerifyElseCrashSz(false, "Must crash"));
+  }
+
+  TEST_METHOD(TestCheckCrashSucceededWithMessage)
+  {
+    TestCheckCrash(VerifyElseCrashSz(false, "Must crash"), "Test must succeed");
+  }
+
+  TEST_METHOD(TestCheckCrashSucceededWithMessageArgs)
+  {
+    TestCheckCrash(VerifyElseCrashSz(false, "Must crash"), "Test %s %s %d", "must", "succeed", 2);
+  }
+
+  TEST_METHOD(TestCheckTerminateFailed)
+  {
+    TestCheckTerminate(2 + 2);
+  }
+
+  TEST_METHOD(TestCheckTerminateFailedWithMessage)
+  {
+    TestCheckTerminate(2 + 2, "Test must fail");
+  }
+
+  TEST_METHOD(TestCheckTerminateFailedWithMessageArgs)
+  {
+    TestCheckTerminate(2 + 2, "Test %s %s %d", "must", "fail", 2);
+  }
+
+  TEST_METHOD(TestCheckTerminateSucceeded)
+  {
+    TestCheckTerminate(std::terminate());
+  }
+
+  TEST_METHOD(TestCheckTerminateSucceededWithMessage)
+  {
+    TestCheckTerminate(std::terminate(), "Test must succeed");
+  }
+
+  TEST_METHOD(TestCheckTerminateSucceededWithMessageArgs)
+  {
+    TestCheckTerminate(std::terminate(), "Test %s %s %d", "must", "succeed", 2);
+  }
+
+  TEST_METHOD(TestCheckExceptionFailed)
+  {
+    TestCheckException(std::exception, 2 + 2);
+  }
+
+  TEST_METHOD(TestCheckExceptionFailedWithMessage)
+  {
+    TestCheckException(std::exception, 2 + 2, "Test must fail");
+  }
+
+  TEST_METHOD(TestCheckExceptionFailedWithMessageArgs)
+  {
+    TestCheckException(std::exception, 2 + 2, "Test %s %s %d", "must", "fail", 2);
+  }
+
+  TEST_METHOD(TestCheckExceptionSucceeded)
+  {
+    TestCheckException(std::exception, throw std::exception());
+  }
+
+  TEST_METHOD(TestCheckExceptionSucceededWithMessage)
+  {
+    TestCheckException(std::exception, throw std::exception(), "Test must succeed");
+  }
+
+  TEST_METHOD(TestCheckExceptionSucceededWithMessageArgs)
+  {
+    TestCheckException(std::exception, throw std::exception(), "Test %s %s %d", "must", "succeed", 2);
+  }
+
+  TEST_METHOD(TestCheckNoThrowFailed)
+  {
+    TestCheckNoThrow(throw std::exception());
+  }
+
+  TEST_METHOD(TestCheckNoThrowFailedWithMessage)
+  {
+    TestCheckNoThrow(throw std::exception(), "Test must fail");
+  }
+
+  TEST_METHOD(TestCheckNoThrowFailedWithMessageArgs)
+  {
+    TestCheckNoThrow(throw std::exception(), "Test %s %s %d", "must", "fail", 2);
+  }
+
+  TEST_METHOD(TestCheckNoThrowSucceeded)
+  {
+    TestCheckNoThrow(2 + 2);
+  }
+
+  TEST_METHOD(TestCheckNoThrowSucceededWithMessage)
+  {
+    TestCheckNoThrow(2 + 2, "Test must succeed");
+  }
+
+  TEST_METHOD(TestCheckNoThrowSucceededWithMessageArgs)
+  {
+    TestCheckNoThrow(2 + 2, "Test %s %s %d", "must", "succeed", 2);
+  }
+#endif
+};

--- a/libs/object/CMakeLists.txt
+++ b/libs/object/CMakeLists.txt
@@ -4,9 +4,9 @@
 liblet(object
   DEPENDS
     Mso::comUtil
-    Mso::cppType
     Mso::crash
     Mso::debugAssertApi
     Mso::memoryApi
     Mso::platformAdapters
+    Mso::typeTraits
 )

--- a/libs/object/include/object/objectRefCount.h
+++ b/libs/object/include/object/objectRefCount.h
@@ -25,7 +25,7 @@
 #pragma push_macro("new")
 #undef new
 
-#define MSO_OBJECT_SIMPLEREFCOUNT(TObject)                                                        \
+#define MSO_OBJECT_SIMPLEREFCOUNT(TObject)                                                         \
 public:                                                                                            \
   bool IsUniqueRef() const noexcept                                                                \
   {                                                                                                \
@@ -38,7 +38,7 @@ public:                                                                         
   MSO_NO_COPY_CTOR_AND_ASSIGNMENT(TObject)
 
 #define MSO_OBJECT_NOREFCOUNT(TObject) \
-public:                                 \
+public:                                \
   MSO_NO_COPY_CTOR_AND_ASSIGNMENT(TObject)
 
 namespace Mso {

--- a/libs/object/include/object/objectWithWeakRef.h
+++ b/libs/object/include/object/objectWithWeakRef.h
@@ -70,7 +70,7 @@ To implement your classes please use classes defined in the msoUnknownObject.h o
 #pragma push_macro("new")
 #undef new
 
-#define MSO_OBJECT_WEAKREFCOUNT(TObject)                                       \
+#define MSO_OBJECT_WEAKREFCOUNT(TObject)                                        \
 public:                                                                         \
   Mso::ObjectWeakRef& GetWeakRef() const noexcept                               \
   {                                                                             \

--- a/libs/object/tests/unknownObjectTest.cpp
+++ b/libs/object/tests/unknownObjectTest.cpp
@@ -1711,7 +1711,7 @@ TEST_CLASS (UnknownObjectTest)
       IBaseSample3* base3 = query_cast<IBaseSample3*>(base1);
       TestAssert::IsNull(base3);
       UnknownSample3* unknown2 = query_cast<UnknownSample3*>(base2);
-      OACR_USE_PTR(unknown2); // We do not want to make unknown2 const in this test.
+      //OACR_USE_PTR(unknown2); // We do not want to make unknown2 const in this test.
       TestAssert::AreEqual(2, unknown2->GetValue2());
     }
     TestAssert::IsTrue(deleted);
@@ -1842,7 +1842,7 @@ TEST_CLASS (UnknownObjectTest)
       IBaseSample3* base3 = query_cast<IBaseSample3*>(base1);
       TestAssert::IsNull(base3);
       UnknownSample6* unknown2 = query_cast<UnknownSample6*>(base2);
-      OACR_USE_PTR(unknown2); // We do not want to make unknown2 const in this test.
+      // OACR_USE_PTR(unknown2); // We do not want to make unknown2 const in this test.
       TestAssert::AreEqual(2, unknown2->GetValue2());
     }
     TestAssert::IsTrue(deleted);

--- a/libs/platformAdapters/include/platformAdapters/IUnknownShim.h
+++ b/libs/platformAdapters/include/platformAdapters/IUnknownShim.h
@@ -2,6 +2,8 @@
 // Licensed under the MIT license.
 
 #pragma once
+#ifndef MSO_PLATFORMADAPTERS_IUNKNOWNSHIM_H
+#define MSO_PLATFORMADAPTERS_IUNKNOWNSHIM_H
 #include <guid/msoGuid.h>
 #include <platformAdapters/types.h>
 #include <platformAdapters/windowsFirst.h>
@@ -94,3 +96,9 @@ struct IUnknown
 #define __RPC_FAR
 
 #endif
+
+namespace Mso {
+using IUnknown = ::IUnknown;
+}
+
+#endif // MSO_PLATFORMADAPTERS_IUNKNOWNSHIM_H

--- a/libs/platformAdapters/include/platformAdapters/windowsFirst.h
+++ b/libs/platformAdapters/include/platformAdapters/windowsFirst.h
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+#pragma once
+#ifndef MSO_PLATFORMADAPTERS_WINDOWSFIRST_H
+#define MSO_PLATFORMADAPTERS_WINDOWSFIRST_H
+
 /**
   Header to properly include windows.h
 */
-#pragma once
-#ifndef LIBLET_PLATFORMADAPTERS_WINDOWSFIRST_H
-#define LIBLET_PLATFORMADAPTERS_WINDOWSFIRST_H
 
 #ifdef MS_TARGET_WINDOWS
 
@@ -19,4 +20,4 @@
 
 #endif // MS_TARGET_WINDOWS
 
-#endif // LIBLET_PLATFORMADAPTERS_WINDOWSFIRST_H
+#endif // MSO_PLATFORMADAPTERS_WINDOWSFIRST_H

--- a/libs/smartPtr/CMakeLists.txt
+++ b/libs/smartPtr/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 liblet(smartPtr
   DEPENDS
-    Mso::cppType
     Mso::crash
     Mso::platformAdapters
+    Mso::typeTraits
 )

--- a/libs/typeTraits/include/CMakeLists.txt
+++ b/libs/typeTraits/include/CMakeLists.txt
@@ -3,5 +3,7 @@
 
 liblet_includes(
   INCLUDES
+    typeTraits/sfinae.h
+    typeTraits/tags.h
     typeTraits/typeTraits.h
 )

--- a/libs/typeTraits/include/typeTraits/sfinae.h
+++ b/libs/typeTraits/include/typeTraits/sfinae.h
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+#ifndef MSO_TYPETRAITS_SFINAE_H
+#define MSO_TYPETRAITS_SFINAE_H
+
+//! Helper definitions to implement conditional template method compilation
+//! based on SFINAE principles: https://en.cppreference.com/w/cpp/language/sfinae
+
+#include <type_traits>
+
+namespace Mso {
+
+template <class TBase, class TDerived>
+using EnableIfIsBaseOf = typename std::enable_if<std::is_base_of<TBase, TDerived>::value, int>::type;
+
+} // namespace Mso
+
+#endif // MSO_TYPETRAITS_SFINAE_H

--- a/libs/typeTraits/include/typeTraits/tags.h
+++ b/libs/typeTraits/include/typeTraits/tags.h
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+#ifndef MSO_TYPETRAITS_TAGS_H
+#define MSO_TYPETRAITS_TAGS_H
+
+namespace Mso {
+
+struct AttachTagType
+{
+  constexpr AttachTagType() noexcept {}
+};
+
+constexpr AttachTagType AttachTag;
+
+} // namespace Mso
+
+#endif // MSO_TYPETRAITS_TAGS_H

--- a/libs/typeTraits/include/typeTraits/typeTraits.h
+++ b/libs/typeTraits/include/typeTraits/typeTraits.h
@@ -5,12 +5,11 @@
   Various C++ templates to help with compile-time type information.
 */
 #pragma once
-#ifndef LIBLET_CPPTYPE_TYPETRAITS_H
-#define LIBLET_CPPTYPE_TYPETRAITS_H
-#ifdef __cplusplus
+#ifndef MSO_TYPETRAITS_TYPETRAITS_H
+#define MSO_TYPETRAITS_TYPETRAITS_H
 
 #include <type_traits>
-#include <compilerAdapters/declspecDefinitions.h>
+#include "compilerAdapters/declspecDefinitions.h"
 
 namespace Mso {
 
@@ -281,6 +280,4 @@ struct LargestType<T1, T2, Ts...>
 
 } // namespace Mso
 
-#endif // __cplusplus
-
-#endif // LIBLET_CPPTYPE_TYPETRAITS_H
+#endif // MSO_TYPETRAITS_TYPETRAITS_H


### PR DESCRIPTION
In the https://github.com/microsoft/react-native-windows repo we have adopted the Mso as a source and did a number of changes there. This PR is a second PR in a series of changes required to bring the changes from the RNW repo and replace Mso there with the one published from this https://github.com/microsoft/Mso repo.

In this PR we update the following liblets:
- cppExtensions
- crash
- debugAssertApi
- guid
- motifCpp
- oacr
- platformAdapters
- typeTraits