### PR TITLE
Updated motifCpp and guid liblets from RNW Mso fork

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -3,7 +3,6 @@
         {
             "name": "Linux",
             "includePath": [
-                "${workspaceFolder}/**",
                 "${workspaceFolder}/libs/compilerAdapters/include",
                 "${workspaceFolder}/libs/comUtil/include",
                 "${workspaceFolder}/libs/cppExtensions/include",
@@ -21,7 +20,8 @@
                 "${workspaceFolder}/libs/platform_posix/include",
                 "${workspaceFolder}/libs/smartPtr/include",
                 "${workspaceFolder}/libs/tagUtils/include",
-                "${workspaceFolder}/libs/typeTraits/include"
+                "${workspaceFolder}/libs/typeTraits/include",
+                "${workspaceFolder}/**"
             ],
             "defines": [],
             "compilerPath": "/usr/bin/clang",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,16 @@
   "search.exclude": {
     "**/node_modules": true,
     "**/dist": true
-  }
+  },
+  "cSpell.words": [
+    "GTEST",
+    "HRESULT",
+    "MOTIFCPP",
+    "MOTIFCPPTEST",
+    "OACR",
+    "STREQ",
+    "STRNE",
+    "XCTEST",
+    "unwinded"
+  ]
 }

--- a/change/@microsoft-mso-2020-04-05-15-48-50-MS_MotifCppUpdate.json
+++ b/change/@microsoft-mso-2020-04-05-15-48-50-MS_MotifCppUpdate.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updated mortifCpp and guid liblets from RNW Mso fork",
+  "packageName": "@microsoft/mso",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-05T22:48:50.448Z"
+}

--- a/external/gtest/CMakeLists.txt
+++ b/external/gtest/CMakeLists.txt
@@ -5,12 +5,16 @@ if(MSO_ENABLE_UNIT_TESTS)
   # the following code to fetch googletest
   # is inspired by and adapted after:
   #   - https://cmake.org/cmake/help/v3.11/module/FetchContent.html
+  #
+  # We use version of GTest as in the https://github.com/Microsoft/TestAdapterForGoogleTest
+  # It allows to run GTests in Visual Studio and ADO.
+  # Please update the GIT_TAG below after the TAFGT is updated the reference.
   include(FetchContent)
 
   FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG        origin/master
+    GIT_TAG        2fe3bd994b3189899d93f1d5a881e725e046fdc2
     GIT_SHALLOW    1
     GIT_PROGRESS   1
   )

--- a/libs/cppExtensions/include/CMakeLists.txt
+++ b/libs/cppExtensions/include/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 liblet_includes(
   INCLUDES
+    cppExtensions/array.h
     cppExtensions/autoRestore.h
     cppExtensions/stringLiteral.h
   INCLUDES_WIN

--- a/libs/cppExtensions/include/cppExtensions/array.h
+++ b/libs/cppExtensions/include/cppExtensions/array.h
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+#ifndef MSO_CPPEXTENSIONS_AUTORESTORE_H
+#define MSO_CPPEXTENSIONS_AUTORESTORE_H
+
+#include <cstddef>
+
+namespace Mso {
+//! Return compile-time size of an array.
+//! It can be used instead of MSVC _countof macro
+template <class T, size_t N>
+constexpr size_t SizeOf([[maybe_unused]] T (&arr)[N]) noexcept
+{
+  return N;
+}
+
+} // namespace Mso
+
+#endif // MSO_CPPEXTENSIONS_AUTORESTORE_H

--- a/libs/guid/tests/guidTest.cpp
+++ b/libs/guid/tests/guidTest.cpp
@@ -4,6 +4,7 @@
 #include <guid/msoGuid.h>
 #include <motifCpp/testCheck.h>
 #include <compilerAdapters/declspecDefinitions.h>
+#include <cppExtensions/array.h>
 
 MSO_STRUCT_GUID(IBaseInterface, "38E23DC7-92B1-4B21-B5FE-6EA786817915")
 struct DECLSPEC_NOVTABLE IBaseInterface
@@ -99,90 +100,92 @@ MSO_DEFINE_GUID_TOKEN(MyProductId2, "AABFD353-B463-41A2-B04C-9A6AB7541D20")
 
 MSO_DEFINE_GUID_TOKEN(FailingToParseId, "A39D5FC8-0641-4EEE-8C97-DDEF114D487D")
 
-#if 0
-TEST_CLASS (GuidTest){
-  static std::string GuidToString(const GUID& guid){char str[37];
-sprintf_s(
-    str,
-    _countof(str),
-    "%08lX-%04hX-%04hX-%02hhX%02hhX-%02hhX%02hhX%02hhX%02hhX%02hhX%02hhX",
-    guid.Data1,
-    guid.Data2,
-    guid.Data3,
-    guid.Data4[0],
-    guid.Data4[1],
-    guid.Data4[2],
-    guid.Data4[3],
-    guid.Data4[4],
-    guid.Data4[5],
-    guid.Data4[6],
-    guid.Data4[7]);
-return str;
-}
-
-TEST_METHOD(TestTypeGuids)
+TEST_CLASS (GuidTest)
 {
-  TestAssert::AreEqual(std::string("38E23DC7-92B1-4B21-B5FE-6EA786817915"), GuidToString(__uuidof(IBaseInterface)));
-  TestAssert::AreEqual(std::string("9E11BC42-1416-45B1-9712-AA4AAD87F78B"), GuidToString(__uuidof(IDerivedInterface)));
-  TestAssert::AreEqual(std::string("866E3389-0194-4416-94CE-6BE8A5185387"), GuidToString(__uuidof(MyClass)));
-  TestAssert::AreEqual(
-      std::string("BAA524C8-F5D1-4CE7-AE24-1FF5EAB306B2"), GuidToString(__uuidof(AlreadyDefinedType1)));
-  TestAssert::AreEqual(
-      std::string("8C76ECFE-0715-4DA1-9746-2FD4DE39118F"), GuidToString(__uuidof(AlreadyDefinedType2)));
-}
+  static std::string GuidToString(const GUID& guid)
+  {
+    char str[37];
+    snprintf(
+        str,
+        Mso::SizeOf(str),
+        "%08X-%04hX-%04hX-%02hhX%02hhX-%02hhX%02hhX%02hhX%02hhX%02hhX%02hhX",
+        guid.Data1,
+        guid.Data2,
+        guid.Data3,
+        guid.Data4[0],
+        guid.Data4[1],
+        guid.Data4[2],
+        guid.Data4[3],
+        guid.Data4[4],
+        guid.Data4[5],
+        guid.Data4[6],
+        guid.Data4[7]);
+    return str;
+  }
 
-TEST_METHOD(TestTypeGuids_InNamespace)
-{
-  TestAssert::AreEqual(
-      std::string("86DE7178-00E6-4A40-8B2C-BA2FBFFB4D06"),
-      GuidToString(__uuidof(MyAppTest::MyDetails::IBaseInterface2)));
-  TestAssert::AreEqual(
-      std::string("C91CAD11-98AB-4218-952F-87509F8F2116"),
-      GuidToString(__uuidof(MyAppTest::MyDetails::IDerivedInterface2)));
-  TestAssert::AreEqual(
-      std::string("06A68045-D24C-4816-84DC-C18888EC46A9"), GuidToString(__uuidof(MyAppTest::MyDetails::MyClass2)));
-  TestAssert::AreEqual(
-      std::string("6B2050DF-6C60-48ED-809D-A88B2476E5A2"),
-      GuidToString(__uuidof(MyAppTest::MyDetails::AlreadyDefinedType21)));
-  TestAssert::AreEqual(
-      std::string("78CEA0B9-2AC5-4FD0-8EE8-C02836BE800D"),
-      GuidToString(__uuidof(MyAppTest::MyDetails::AlreadyDefinedType22)));
-}
+  TEST_METHOD(TestTypeGuids)
+  {
+    TestAssert::AreEqual(std::string("38E23DC7-92B1-4B21-B5FE-6EA786817915"), GuidToString(__uuidof(IBaseInterface)));
+    TestAssert::AreEqual(
+        std::string("9E11BC42-1416-45B1-9712-AA4AAD87F78B"), GuidToString(__uuidof(IDerivedInterface)));
+    TestAssert::AreEqual(std::string("866E3389-0194-4416-94CE-6BE8A5185387"), GuidToString(__uuidof(MyClass)));
+    TestAssert::AreEqual(
+        std::string("BAA524C8-F5D1-4CE7-AE24-1FF5EAB306B2"), GuidToString(__uuidof(AlreadyDefinedType1)));
+    TestAssert::AreEqual(
+        std::string("8C76ECFE-0715-4DA1-9746-2FD4DE39118F"), GuidToString(__uuidof(AlreadyDefinedType2)));
+  }
 
-TEST_METHOD(TestTypeGuids_uuidof_AsTemplateParameter)
-{
-  auto h1 = MyGuidHolder<__uuidof(IBaseInterface)>();
-  TestAssert::AreEqual(std::string("38E23DC7-92B1-4B21-B5FE-6EA786817915"), GuidToString(h1.GetGuid()));
-  auto h2 = MyGuidHolder<__uuidof(MyAppTest::MyDetails::IBaseInterface2)>();
-  TestAssert::AreEqual(std::string("86DE7178-00E6-4A40-8B2C-BA2FBFFB4D06"), GuidToString(h2.GetGuid()));
-}
+  TEST_METHOD(TestTypeGuids_InNamespace)
+  {
+    TestAssert::AreEqual(
+        std::string("86DE7178-00E6-4A40-8B2C-BA2FBFFB4D06"),
+        GuidToString(__uuidof(MyAppTest::MyDetails::IBaseInterface2)));
+    TestAssert::AreEqual(
+        std::string("C91CAD11-98AB-4218-952F-87509F8F2116"),
+        GuidToString(__uuidof(MyAppTest::MyDetails::IDerivedInterface2)));
+    TestAssert::AreEqual(
+        std::string("06A68045-D24C-4816-84DC-C18888EC46A9"), GuidToString(__uuidof(MyAppTest::MyDetails::MyClass2)));
+    TestAssert::AreEqual(
+        std::string("6B2050DF-6C60-48ED-809D-A88B2476E5A2"),
+        GuidToString(__uuidof(MyAppTest::MyDetails::AlreadyDefinedType21)));
+    TestAssert::AreEqual(
+        std::string("78CEA0B9-2AC5-4FD0-8EE8-C02836BE800D"),
+        GuidToString(__uuidof(MyAppTest::MyDetails::AlreadyDefinedType22)));
+  }
 
-TEST_METHOD(TestTypeGuids_TypeHasGuid)
-{
-  TestAssert::IsTrue(Mso::TypeHasGuid<IBaseInterface>::Value);
-  TestAssert::IsTrue(Mso::TypeHasGuid<IDerivedInterface>::Value);
-  TestAssert::IsTrue(Mso::TypeHasGuid<MyClass>::Value);
-  TestAssert::IsTrue(Mso::TypeHasGuid<AlreadyDefinedType1>::Value);
-  TestAssert::IsTrue(Mso::TypeHasGuid<AlreadyDefinedType2>::Value);
-  TestAssert::IsFalse(Mso::TypeHasGuid<TypeWithoutGuid>::Value);
+  TEST_METHOD(TestTypeGuids_uuidof_AsTemplateParameter)
+  {
+    auto h1 = MyGuidHolder<__uuidof(IBaseInterface)>();
+    TestAssert::AreEqual(std::string("38E23DC7-92B1-4B21-B5FE-6EA786817915"), GuidToString(h1.GetGuid()));
+    auto h2 = MyGuidHolder<__uuidof(MyAppTest::MyDetails::IBaseInterface2)>();
+    TestAssert::AreEqual(std::string("86DE7178-00E6-4A40-8B2C-BA2FBFFB4D06"), GuidToString(h2.GetGuid()));
+  }
 
-  TestAssert::IsTrue(Mso::TypeHasGuid<MyAppTest::MyDetails::IBaseInterface2>::Value);
-  TestAssert::IsTrue(Mso::TypeHasGuid<MyAppTest::MyDetails::IDerivedInterface2>::Value);
-  TestAssert::IsTrue(Mso::TypeHasGuid<MyAppTest::MyDetails::MyClass2>::Value);
-  TestAssert::IsTrue(Mso::TypeHasGuid<MyAppTest::MyDetails::AlreadyDefinedType21>::Value);
-  TestAssert::IsTrue(Mso::TypeHasGuid<MyAppTest::MyDetails::AlreadyDefinedType22>::Value);
-  TestAssert::IsFalse(Mso::TypeHasGuid<MyAppTest::MyDetails::TypeWithoutGuid2>::Value);
-}
+  TEST_METHOD(TestTypeGuids_TypeHasGuid)
+  {
+    TestAssert::IsTrue(Mso::TypeHasGuid<IBaseInterface>::Value);
+    TestAssert::IsTrue(Mso::TypeHasGuid<IDerivedInterface>::Value);
+    TestAssert::IsTrue(Mso::TypeHasGuid<MyClass>::Value);
+    TestAssert::IsTrue(Mso::TypeHasGuid<AlreadyDefinedType1>::Value);
+    TestAssert::IsTrue(Mso::TypeHasGuid<AlreadyDefinedType2>::Value);
+    TestAssert::IsFalse(Mso::TypeHasGuid<TypeWithoutGuid>::Value);
 
-TEST_METHOD(TestTypeGuids_DefineGuidToken)
-{
-  TestAssert::AreEqual(std::string("67A42775-79F7-469D-8A28-7348ED9F8D71"), GuidToString(__uuidof_token(MyProductId)));
-  TestAssert::AreEqual(
-      std::string("AABFD353-B463-41A2-B04C-9A6AB7541D20"),
-      GuidToString(__uuidof_token(MyAppTest::MyDetails::MyProductId2)));
-  TestAssert::AreEqual(
-      std::string("A39D5FC8-0641-4EEE-8C97-DDEF114D487D"), GuidToString(__uuidof_token(FailingToParseId)));
-}
-}
-;
-#endif
+    TestAssert::IsTrue(Mso::TypeHasGuid<MyAppTest::MyDetails::IBaseInterface2>::Value);
+    TestAssert::IsTrue(Mso::TypeHasGuid<MyAppTest::MyDetails::IDerivedInterface2>::Value);
+    TestAssert::IsTrue(Mso::TypeHasGuid<MyAppTest::MyDetails::MyClass2>::Value);
+    TestAssert::IsTrue(Mso::TypeHasGuid<MyAppTest::MyDetails::AlreadyDefinedType21>::Value);
+    TestAssert::IsTrue(Mso::TypeHasGuid<MyAppTest::MyDetails::AlreadyDefinedType22>::Value);
+    TestAssert::IsFalse(Mso::TypeHasGuid<MyAppTest::MyDetails::TypeWithoutGuid2>::Value);
+  }
+
+  TEST_METHOD(TestTypeGuids_DefineGuidToken)
+  {
+    TestAssert::AreEqual(
+        std::string("67A42775-79F7-469D-8A28-7348ED9F8D71"), GuidToString(__uuidof_token(MyProductId)));
+    TestAssert::AreEqual(
+        std::string("AABFD353-B463-41A2-B04C-9A6AB7541D20"),
+        GuidToString(__uuidof_token(MyAppTest::MyDetails::MyProductId2)));
+    TestAssert::AreEqual(
+        std::string("A39D5FC8-0641-4EEE-8C97-DDEF114D487D"), GuidToString(__uuidof_token(FailingToParseId)));
+  }
+};

--- a/libs/motifCpp/include/motifCpp/motifCppTest.h
+++ b/libs/motifCpp/include/motifCpp/motifCppTest.h
@@ -2,28 +2,426 @@
 // Licensed under the MIT license.
 
 #pragma once
+#ifndef MSO_MOTIFCPP_MOTIFCPPTEST_H
+#define MSO_MOTIFCPP_MOTIFCPPTEST_H
 
 #include <csetjmp>
 #include <csignal>
 #include <cstdarg>
 #include <functional>
+#include <string>
 #include <type_traits>
+#include "platformAdapters/IUnknownShim.h"
+#include "motifCpp/gTestAdapter.h"
+#include "oacr/oacr.h"
 
-#include <compilerAdapters/compilerWarnings.h>
-#include <oacr/oacr.h>
-#include <platformAdapters/IUnknownShim.h>
+using WCHAR = wchar_t;
 
-#if defined(MSO_USE_GTEST)
-#include <motifCpp/gTestAdapter.h>
-#elif defined(MSO_USE_XCTEST)
-#include <motifCpp/xcTestAdapter.h>
-#else
-#error "Undefined unit test framework"
-#endif
+#define GTEST_ASSERT_AT_(file, line, expression, on_failure)    \
+  GTEST_AMBIGUOUS_ELSE_BLOCKER_                                 \
+  if (const ::testing::AssertionResult gtest_ar = (expression)) \
+    ;                                                           \
+  else                                                          \
+    on_failure(file, line, gtest_ar.failure_message())
 
-typedef wchar_t WCHAR;
+#define GTEST_FATAL_FAILURE_AT_(file, line, message) \
+  return GTEST_MESSAGE_AT_(file, line, message, ::testing::TestPartResult::kFatalFailure)
 
 namespace TestAssert {
+
+inline std::string FormatMsg(char const* format, ...) noexcept
+{
+  std::string result;
+  va_list vlist;
+  va_start(vlist, format);
+  auto size = std::vsnprintf(nullptr, 0, format, vlist);
+  result.append(size + 1, '\0');
+  std::vsnprintf(&result[0], size + 1, format, vlist);
+  result.resize(size);
+  va_end(vlist);
+  return result;
+}
+
+inline std::string FormatCustomMsg(int line, char const* message = "")
+{
+  return FormatMsg(
+      "    Line: %d%s%s",
+      line,
+      (message == nullptr || message[0] == '\0') ? "" : "\n",
+      message == nullptr ? "" : message);
+}
+
+inline void FailInternalAt(char const* file, int line, char const* message, std::string&& errorMessage)
+{
+  GTEST_FATAL_FAILURE_AT_(file, line, "") << errorMessage << FormatCustomMsg(line, message).c_str();
+}
+
+inline void FailAt(char const* file, int line, char const* message = "")
+{
+  FailInternalAt(file, line, message, "Failed\n");
+}
+
+inline void IsTrueAt(char const* file, int line, bool condition, char const* exprStr, char const* message = "")
+{
+  if (!condition)
+  {
+    FailInternalAt(
+        file,
+        line,
+        message,
+        FormatMsg(
+            "Expected: [ %s ] is true\n"
+            "  Actual: it is false\n",
+            exprStr));
+  }
+}
+
+template <class T, std::enable_if_t<!std::is_same_v<bool, T>, int> = 1>
+inline void IsTrueAt(char const* file, int line, T condition, char const* exprStr, char const* message = "")
+{
+  return IsTrueAt(file, line, !!condition, exprStr, message);
+}
+
+template <class TExpected, class TActual>
+inline void AreEqualAt(
+    char const* file,
+    int line,
+    TExpected const& expected,
+    TActual const& actual,
+    char const* expectedExpr,
+    char const* actualExpr,
+    char const* message = "")
+{
+  GTEST_ASSERT_AT_(
+      file,
+      line,
+      ::testing::internal::EqHelper<GTEST_IS_NULL_LITERAL_(expected)>::Compare(
+          expectedExpr, actualExpr, expected, actual),
+      GTEST_FATAL_FAILURE_AT_)
+      << FormatCustomMsg(line, message);
+}
+
+template <
+    class TExpected,
+    class TActual,
+    std::enable_if_t<
+        std::is_same_v<TExpected, TActual> && !std::is_same_v<TExpected, WCHAR> && !std::is_same_v<TExpected, char>,
+        int> = 1>
+void AreEqualAt(
+    char const* file,
+    int line,
+    TExpected const* expected,
+    TActual const* actual,
+    char const* expectedExpr,
+    char const* actualExpr,
+    char const* message = "")
+{
+  GTEST_ASSERT_AT_(
+      file,
+      line,
+      ::testing::internal::EqHelper<GTEST_IS_NULL_LITERAL_(expected)>::Compare(
+          expectedExpr, actualExpr, expected, actual),
+      GTEST_FATAL_FAILURE_AT_)
+      << FormatCustomMsg(line, message);
+}
+
+inline void AreEqualAt(
+    char const* file,
+    int line,
+    WCHAR const* expected,
+    WCHAR const* actual,
+    char const* expectedExpr,
+    char const* actualExpr,
+    char const* message = "")
+{
+  GTEST_ASSERT_AT_(
+      file,
+      line,
+      ::testing::internal::CmpHelperSTREQ(expectedExpr, actualExpr, expected, actual),
+      GTEST_FATAL_FAILURE_AT_)
+      << FormatCustomMsg(line, message);
+}
+
+inline void AreEqualAt(
+    char const* file,
+    int line,
+    char const* expected,
+    char const* actual,
+    char const* expectedExpr,
+    char const* actualExpr,
+    char const* message = "")
+{
+  GTEST_ASSERT_AT_(
+      file,
+      line,
+      ::testing::internal::CmpHelperSTREQ(expectedExpr, actualExpr, expected, actual),
+      GTEST_FATAL_FAILURE_AT_)
+      << FormatCustomMsg(line, message);
+}
+
+inline void AreEqualAt(
+    char const* file,
+    int line,
+    WCHAR* expected,
+    WCHAR const* actual,
+    char const* expectedExpr,
+    char const* actualExpr,
+    char const* message = "")
+{
+  GTEST_ASSERT_AT_(
+      file,
+      line,
+      ::testing::internal::CmpHelperSTREQ(expectedExpr, actualExpr, expected, actual),
+      GTEST_FATAL_FAILURE_AT_)
+      << FormatCustomMsg(line, message);
+}
+
+inline void AreEqualAt(
+    char const* file,
+    int line,
+    char* expected,
+    const char* actual,
+    char const* expectedExpr,
+    char const* actualExpr,
+    const char* message = "")
+{
+  GTEST_ASSERT_AT_(
+      file,
+      line,
+      ::testing::internal::CmpHelperSTREQ(expectedExpr, actualExpr, expected, actual),
+      GTEST_FATAL_FAILURE_AT_)
+      << FormatCustomMsg(line, message);
+}
+
+#ifdef MS_TARGET_WINDOWS
+// Code used for all the C++ exceptions
+constexpr uint32_t EXCEPTION_CPLUSPLUS = static_cast<uint32_t>(0xE06D7363);
+
+inline uint32_t FilterCrashExceptions(uint32_t exceptionCode) noexcept
+{
+  if ((exceptionCode == EXCEPTION_BREAKPOINT) // allow exceptions to get to the debugger
+      || (exceptionCode == EXCEPTION_SINGLE_STEP) // allow exceptions to get to the debugger
+      || (exceptionCode == EXCEPTION_GUARD_PAGE) // allow to crash on memory page access violation
+      || (exceptionCode == EXCEPTION_STACK_OVERFLOW)) // allow to crash on stack overflow
+  {
+    return EXCEPTION_CONTINUE_SEARCH;
+  }
+
+  if (exceptionCode == EXCEPTION_CPLUSPLUS) // log C++ exception and pass it through
+  {
+    FailAt(__FILE__, __LINE__, "Test function did not crash, but exception is thrown!");
+    return EXCEPTION_CONTINUE_SEARCH;
+  }
+
+  return EXCEPTION_EXECUTE_HANDLER;
+}
+
+BEGIN_DISABLE_WARNING_UNREACHABLE_CODE()
+template <class TLambda>
+inline bool ExpectCrashCore(TLambda const& lambda)
+{
+  __try
+  {
+    lambda();
+    return false;
+  }
+  __except (FilterCrashExceptions(GetExceptionCode()))
+  {
+    return true;
+  }
+}
+END_DISABLE_WARNING_UNREACHABLE_CODE()
+
+#else
+
+using SigAction = void (*)(int, siginfo_t*, void*);
+
+// An RAII class that sets custom action for segmentation fault signal and
+// restores the old one in the destructor.
+struct CrashState
+{
+  CrashState(SigAction action) noexcept
+  {
+    sigemptyset(&m_action.sa_mask);
+    m_action.sa_sigaction = action;
+    m_action.sa_flags = SA_NODEFER;
+    sigaction(SIGSEGV, &m_action, &m_oldAction);
+  }
+
+  ~CrashState() noexcept
+  {
+    sigaction(SIGSEGV, &m_oldAction, nullptr);
+  }
+
+private:
+  struct sigaction m_action
+  {
+  };
+  struct sigaction m_oldAction
+  {
+  };
+};
+
+BEGIN_DISABLE_WARNING_FUNCTION_MAY_NOT_CALL_DTOR()
+// Returns true if crash (segmentation fault happened)
+template <class Fn>
+inline bool ExpectCrashCore(const Fn& fn)
+{
+  static sigjmp_buf buf{};
+
+  // Set sigaction and save the previous action to be restored in the end of
+  // function.
+  CrashState crashState{[](int /*signal*/, siginfo_t* /*si*/, void* /*arg*/) { longjmp(buf, 1); }};
+
+  // setjmp originally returns 0, and when longjmp is called it returns 1.
+  if (!setjmp(buf))
+  {
+    fn();
+    return true; // must not be executed if fn() caused crash and the longjmp is executed.
+  }
+  else
+  {
+    return true; // executed if longjmp is executed in the SigAction handler.
+  }
+}
+END_DISABLE_WARNING_FUNCTION_MAY_NOT_CALL_DTOR()
+
+#endif // MS_TARGET_WINDOWS
+
+template <class TLambda>
+inline void
+ExpectCrashAt(char const* file, int line, TLambda const& lambda, char const* exprStr, char const* message = "")
+{
+  if (!ExpectCrashCore(lambda))
+  {
+    FailInternalAt(
+        file,
+        line,
+        message,
+        FormatMsg(
+            "Expected: [ %s ] must crash\n"
+            "  Actual: it does not crash\n",
+            exprStr));
+  }
+}
+
+struct TerminateHandlerRestorer
+{
+  ~TerminateHandlerRestorer() noexcept
+  {
+    std::set_terminate(Handler);
+  }
+
+  std::terminate_handler Handler;
+};
+
+BEGIN_DISABLE_WARNING_FUNCTION_MAY_NOT_CALL_DTOR()
+template <class TLambda>
+inline bool ExpectTerminateCore(TLambda const& lambda)
+{
+  static jmp_buf buf;
+
+  // Set a terminate handler and save the previous terminate handler to be restored in the end of function.
+  TerminateHandlerRestorer terminateRestore = {std::set_terminate([]() { longjmp(buf, 1); })};
+
+  // setjmp originally returns 0, and when longjmp is called it returns 1.
+  if (!setjmp(buf))
+  {
+    lambda();
+    return false; // must not be executed if fn() caused termination and the longjmp is executed.
+  }
+  else
+  {
+    return true; // executed if longjmp is executed in the terminate handler.
+  }
+}
+END_DISABLE_WARNING_FUNCTION_MAY_NOT_CALL_DTOR()
+
+template <class TLambda>
+inline void
+ExpectTerminateAt(char const* file, int line, TLambda const& lambda, char const* exprStr, char const* message = "")
+{
+  if (!ExpectTerminateCore(lambda))
+  {
+    FailInternalAt(
+        file,
+        line,
+        message,
+        FormatMsg(
+            "Expected: [ %s ] must terminate\n"
+            "  Actual: it does not terminate\n",
+            exprStr));
+  }
+}
+
+template <class TException, class TLambda>
+inline void ExpectExceptionAt(
+    char const* file,
+    int line,
+    TLambda const& lambda,
+    char const* exceptionStr,
+    char const* exprStr,
+    char const* message = "")
+{
+  char const* actualIssue = "";
+  bool isFailed = false;
+  bool isExpectedExceptionCaught = false;
+
+  try
+  {
+    lambda();
+  }
+  catch (TException const&)
+  {
+    isExpectedExceptionCaught = true;
+  }
+  catch (...)
+  {
+    isFailed = true;
+    actualIssue = "it throws a different type";
+  }
+
+  if (!isExpectedExceptionCaught && !isFailed)
+  {
+    isFailed = true;
+    actualIssue = "it does not throw";
+  }
+
+  if (isFailed)
+  {
+    FailInternalAt(
+        file,
+        line,
+        message,
+        FormatMsg(
+            "Expected: [ %s ] throws an exception of type %s\n"
+            "  Actual: %s\n",
+            exprStr,
+            exceptionStr,
+            actualIssue));
+  }
+}
+
+template <class TLambda>
+inline void
+ExpectNoThrowAt(char const* file, int line, TLambda const& lambda, char const* exprStr, char const* message = "")
+{
+  try
+  {
+    lambda();
+  }
+  catch (...)
+  {
+    FailInternalAt(
+        file,
+        line,
+        message,
+        FormatMsg(
+            "Expected: [ %s ] does not throw an exception\n"
+            "  Actual: it throws an exception\n",
+            exprStr));
+  }
+}
 
 // Asserts that the specified condition is true, if it is false the unit test will fail
 inline void IsTrue(bool condition, _In_z_ const WCHAR* message = L"")
@@ -62,7 +460,7 @@ template <
     typename ExpectedType,
     typename ActualType,
     typename TEnable = typename std::enable_if<
-        std::is_same<ExpectedType, ActualType>::value && !std::is_same<ExpectedType, wchar_t>::value
+        std::is_same<ExpectedType, ActualType>::value && !std::is_same<ExpectedType, WCHAR>::value
         && !std::is_same<ExpectedType, char>::value>::type>
 void AreEqual(_In_ const ExpectedType* expected, _In_ const ActualType* actual, _In_z_ const WCHAR* message = L"")
 {
@@ -70,7 +468,7 @@ void AreEqual(_In_ const ExpectedType* expected, _In_ const ActualType* actual, 
   ASSERT_EQ(expected, actual) << wstrMessage.c_str();
 }
 
-inline void AreEqual(_In_ const wchar_t* expected, _In_ const wchar_t* actual, _In_z_ const WCHAR* message = L"")
+inline void AreEqual(_In_ const WCHAR* expected, _In_ const WCHAR* actual, _In_z_ const WCHAR* message = L"")
 {
   std::wstring wstrMessage(message);
   ASSERT_STREQ(expected, actual) << wstrMessage.c_str();
@@ -82,7 +480,7 @@ inline void AreEqual(_In_ const char* expected, _In_ const char* actual, _In_z_ 
   ASSERT_STREQ(expected, actual) << wstrMessage.c_str();
 }
 
-inline void AreEqual(_In_ wchar_t* expected, _In_ const wchar_t* actual, _In_z_ const WCHAR* message = L"")
+inline void AreEqual(_In_ WCHAR* expected, _In_ const WCHAR* actual, _In_z_ const WCHAR* message = L"")
 {
   std::wstring wstrMessage(message);
   ASSERT_STREQ(expected, actual) << wstrMessage.c_str();
@@ -106,14 +504,14 @@ template <
     typename ExpectedType,
     typename ActualType,
     typename TEnable = typename std::enable_if<
-        std::is_same<ExpectedType, ActualType>::value && !std::is_same<ExpectedType, wchar_t>::value
+        std::is_same<ExpectedType, ActualType>::value && !std::is_same<ExpectedType, WCHAR>::value
         && !std::is_same<ExpectedType, char>::value>::type>
 void AreNotEqual(_In_ const ExpectedType* expected, _In_ const ActualType* actual, _In_z_ const WCHAR* message = L"")
 {
   AreNotEqual(*expected, *actual, message);
 }
 
-inline void AreNotEqual(_In_ const wchar_t* expected, _In_ const wchar_t* actual, _In_z_ const WCHAR* message = L"")
+inline void AreNotEqual(_In_ const WCHAR* expected, _In_ const WCHAR* actual, _In_z_ const WCHAR* message = L"")
 {
   std::wstring wstrMessage(message);
   ASSERT_STRNE(expected, actual) << wstrMessage.c_str();
@@ -125,7 +523,7 @@ inline void AreNotEqual(_In_ const char* expected, _In_ const char* actual, _In_
   ASSERT_STRNE(expected, actual) << wstrMessage.c_str();
 }
 
-inline void AreNotEqual(_In_ wchar_t* expected, _In_ const wchar_t* actual, _In_z_ const WCHAR* message = L"")
+inline void AreNotEqual(_In_ WCHAR* expected, _In_ const WCHAR* actual, _In_z_ const WCHAR* message = L"")
 {
   std::wstring wstrMessage(message);
   ASSERT_STRNE(expected, actual) << wstrMessage.c_str();
@@ -190,7 +588,7 @@ inline void ExpectException(const std::function<void()>& statement, const WCHAR*
 template <typename ExceptionType>
 inline void ExpectException(
     const std::function<void()>& statement,
-    const std::function<void()>& /*onException*/,
+    const std::function<void()>& onException,
     const WCHAR* message = L"")
 {
   EXPECT_THROW(statement(), ExceptionType) << message;
@@ -211,106 +609,15 @@ inline void HrFailed(HRESULT hr, _In_z_ const WCHAR* message = L"")
   ASSERT_FALSE(SUCCEEDED(hr)) << message;
 }
 
-#ifdef MS_TARGET_WINDOWS
-// Code used for all the C++ exceptions
-static const DWORD EXCEPTION_CPLUSPLUS = static_cast<DWORD>(0xE06D7363);
-
-inline DWORD FilterCrashExceptions(DWORD exceptionCode) noexcept
-{
-  if ((exceptionCode == EXCEPTION_BREAKPOINT) // allow exceptions to get to the debugger
-      || (exceptionCode == EXCEPTION_SINGLE_STEP) // allow exceptions to get to the debugger
-      || (exceptionCode == EXCEPTION_GUARD_PAGE) // allow to crash on memory page access violation
-      || (exceptionCode == EXCEPTION_STACK_OVERFLOW)) // allow to crash on stack overflow
-  {
-    return EXCEPTION_CONTINUE_SEARCH;
-  }
-  if (exceptionCode == EXCEPTION_CPLUSPLUS) // log C++ exception and pass it through
-  {
-    TestAssert::Fail(L"Test function did not crash, but exception is thrown!");
-    return EXCEPTION_CONTINUE_SEARCH;
-  }
-  return EXCEPTION_EXECUTE_HANDLER;
-}
-
-BEGIN_DISABLE_WARNING_UNREACHABLE_CODE()
-template <typename Fn>
-inline bool ExpectCrashCore(const Fn& fn, const WCHAR* /*message*/)
-{
-  __try
-  {
-    fn();
-  }
-  __except (FilterCrashExceptions(GetExceptionCode()))
-  {
-    // Pass(message == nullptr || message[0] == L'\0' ? L"Crash occurred as expected." : message);
-    return true;
-  }
-  // Fail(message == nullptr || message[0] == L'\0' ? L"Test function did not crash!" : message);
-  return false;
-}
-END_DISABLE_WARNING_UNREACHABLE_CODE()
-
-#else
-
-using SigAction = void (*)(int, siginfo_t*, void*);
-
-// An RAII class that sets custom action for segmentation fault signal and
-// restores the old one in the destructor.
-struct CrashState
-{
-  CrashState(SigAction action) noexcept
-  {
-    sigemptyset(&m_action.sa_mask);
-    m_action.sa_sigaction = action;
-    m_action.sa_flags = SA_NODEFER;
-    sigaction(SIGSEGV, &m_action, &m_oldAction);
-  }
-
-  ~CrashState() noexcept
-  {
-    sigaction(SIGSEGV, &m_oldAction, nullptr);
-  }
-
-private:
-  struct sigaction m_action
-  {
-  };
-  struct sigaction m_oldAction
-  {
-  };
-};
-
-// Returns true if crash (segmentation fault happened)
-template <class Fn>
-inline bool ExpectCrashCore(const Fn& fn, const WCHAR* /*message*/)
-{
-  static sigjmp_buf buf{};
-
-  // Set sigaction and save the previous action to be restored in the end of
-  // function.
-  CrashState crashState{[](int /*signal*/, siginfo_t* /*si*/, void* /*arg*/) { longjmp(buf, 1); }};
-
-  // setjmp originally returns 0, and when longjmp is called it returns 1.
-  if (!setjmp(buf))
-  {
-    fn();
-    return true; // must not be executed if fn() caused crash and the longjmp is executed.
-  }
-  else
-  {
-    return true; // executed if longjmp is executed in the SigAction handler.
-  }
-}
-
-#endif
-
 template <typename Fn>
 inline void ExpectVEC(const Fn& fn, const WCHAR* message = L"")
 {
-  if (!ExpectCrashCore(fn, message))
+  if (!ExpectCrashCore(fn))
   {
     Fail(message);
   }
 }
 
 } // namespace TestAssert
+
+#endif // MSO_MOTIFCPP_MOTIFCPPTEST_H

--- a/libs/motifCpp/include/motifCpp/motifCppTest.h
+++ b/libs/motifCpp/include/motifCpp/motifCppTest.h
@@ -585,15 +585,6 @@ inline void ExpectException(const std::function<void()>& statement, const WCHAR*
   EXPECT_THROW(statement(), ExceptionType) << message;
 }
 
-template <typename ExceptionType>
-inline void ExpectException(
-    const std::function<void()>& statement,
-    const std::function<void()>& onException,
-    const WCHAR* message = L"")
-{
-  EXPECT_THROW(statement(), ExceptionType) << message;
-}
-
 inline void ExpectNoThrow(const std::function<void()>& statement, const WCHAR* message = L"")
 {
   EXPECT_NO_THROW(statement()) << message;

--- a/libs/motifCpp/include/motifCpp/testCheck.h
+++ b/libs/motifCpp/include/motifCpp/testCheck.h
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 #pragma once
-#ifndef TEST_TESTCHECK_H
-#define TEST_TESTCHECK_H
+#ifndef MSO_MOTIFCPP_TESTCHECK_H
+#define MSO_MOTIFCPP_TESTCHECK_H
 
 //=============================================================================
 // Test macros for better error reporting.
@@ -11,54 +11,55 @@
 // It allows to write more compact code because we do not need to add comment
 // for every TestAssert.
 //
-// All macros have a form with suffix "L" that accept line number as a parameter.
-// It is done to enable creation of custom check macros that internally
-// use the macros we provide.
+// All macros have a form with suffix "At" that accept file name and line number
+// as parameters. They can be used to enable creation of custom check macros
+// that internally use the macros we provide.
+//
+// The "M" suffix allows to provide a message or a printf-like format string
+// with arguments. (In C++20 we can combine them with macros without suffix.)
 //=============================================================================
 
-#include <compilerAdapters/compilerWarnings.h>
-#include <motifCpp/assert_motifApi.h>
-#include <csetjmp>
-#include <csignal>
-
-//=============================================================================
-// A helper macro to provide current line number as a wide char string.
-//=============================================================================
-#ifndef MSO_TO_STR
-#define MSO_INTERNAL_TO_STR(value) #value
-#define MSO_TO_STR(value) MSO_INTERNAL_TO_STR(value)
-#endif
-
-#ifndef MSO_WIDE_STR
-#define MSO_INTERNAL_WIDE_STR(str) L##str
-#define MSO_WIDE_STR(str) MSO_INTERNAL_WIDE_STR(str)
-#endif
-
-#define MSO_LINE_STR MSO_TO_STR(__LINE__)
-#define MSO_LINE_WIDE_STR MSO_WIDE_STR(MSO_LINE_STR)
+#include "motifCpp/assert_motifApi.h"
 
 //=============================================================================
 // TestCheckFail fails the test unconditionally.
 //=============================================================================
-#define TestCheckFailL(message, line) TestAssert::Fail(MSO_WIDE_STR("Line: " line " " message))
-#define TestCheckFail(message) TestCheckFailL(message, MSO_LINE_STR)
+#define TestCheckFailAtM(file, line, ...) TestAssert::FailAt(file, line, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
+#define TestCheckFailAt(file, line) TestAssert::FailAt(file, line, TestAssert::FormatMsg("").c_str())
+#define TestCheckFailM(...) TestCheckFailAtM(__FILE__, __LINE__, __VA_ARGS__)
+#define TestCheckFail() TestCheckFailAt(__FILE__, __LINE__)
 
 //=============================================================================
 // TestCheck checks if provided expression evaluates to true.
 // If check fails then it reports the line number and the failed expression.
+//
+// Note that we convert expression to string before we pass it to an
+// Internal macro. This is for better message in case if expression is a macro.
+// It will be shown as macro usage rather than macro being expanded.
 //=============================================================================
-#define TestCheckL(expr, line) TestAssert::IsTrue(expr, MSO_WIDE_STR("Line: " line " [ " MSO_TO_STR(expr) " ]"))
-#define TestCheck(expr) TestCheckL(expr, MSO_LINE_STR)
+#define TestCheckAtInternal(file, line, expr, exprStr, ...) \
+  TestAssert::IsTrueAt(file, line, expr, exprStr, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
+#define TestCheckAtM(file, line, expr, ...) TestCheckAtInternal(file, line, expr, #expr, __VA_ARGS__)
+#define TestCheckAt(file, line, expr) TestCheckAtInternal(file, line, expr, #expr, "")
+#define TestCheckM(expr, ...) TestCheckAtInternal(__FILE__, __LINE__, expr, #expr, __VA_ARGS__)
+#define TestCheck(expr) TestCheckAtInternal(__FILE__, __LINE__, expr, #expr, "")
 
 //=============================================================================
 // TestCheckEqual checks if two provided values are equal.
 // If check fails then it reports the line number and the failed expression.
 // In addition the TestAssert::AreEqual reports expected and actual values.
 //=============================================================================
-#define TestCheckEqualL(expected, actual, line) \
-  TestAssert::AreEqual(                         \
-      expected, actual, MSO_WIDE_STR("Line: " line " [ " MSO_TO_STR(expected) " == " MSO_TO_STR(actual) " ]"))
-#define TestCheckEqual(expected, actual) TestCheckEqualL(expected, actual, MSO_LINE_STR)
+#define TestCheckEqualAtInternal(file, line, expected, actual, expectedStr, actualStr, ...) \
+  TestAssert::AreEqualAt(                                                                   \
+      file, line, expected, actual, expectedStr, actualStr, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
+#define TestCheckEqualAtM(file, line, expected, actual, ...) \
+  TestCheckEqualAtInternal(file, line, expected, actual, #expected, #actual, __VA_ARGS__)
+#define TestCheckEqualAt(file, line, expected, actual) \
+  TestCheckEqualAtInternal(file, line, expected, actual, #expected, #actual, "")
+#define TestCheckEqualM(expected, actual, ...) \
+  TestCheckEqualAtInternal(__FILE__, __LINE__, expected, actual, #expected, #actual, __VA_ARGS__)
+#define TestCheckEqual(expected, actual) \
+  TestCheckEqualAtInternal(__FILE__, __LINE__, expected, actual, #expected, #actual, "")
 
 //=============================================================================
 // TestCheckIgnore ignores the provided expression.
@@ -70,15 +71,13 @@
 //=============================================================================
 // TestCheckCrash expects that the provided expression causes a crash.
 //=============================================================================
-//	Mso::IgnoreAllAsserts ignore;
-#define TestCheckCrashL(expr, line) \
-  TestAssert::ExpectVEC(            \
-      [&]() {                       \
-        OACR_POSSIBLE_THROW;        \
-        expr;                       \
-      },                            \
-      MSO_WIDE_STR("Line: " line " Must crash: [ " MSO_TO_STR(expr) " ]"))
-#define TestCheckCrash(expr) TestCheckCrashL(expr, MSO_LINE_STR)
+#define TestCheckCrashAtInternal(file, line, expr, exprStr, ...) \
+  TestAssert::ExpectCrashAt(                                     \
+      file, line, [&]() { expr; }, exprStr, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
+#define TestCheckCrashAtM(file, line, expr, ...) TestCheckCrashAtInternal(file, line, expr, #expr, __VA_ARGS__)
+#define TestCheckCrashAt(file, line, expr) TestCheckCrashAtInternal(file, line, expr, #expr, "")
+#define TestCheckCrashM(expr, ...) TestCheckCrashAtInternal(__FILE__, __LINE__, expr, #expr, __VA_ARGS__)
+#define TestCheckCrash(expr) TestCheckCrashAtInternal(__FILE__, __LINE__, expr, #expr, "")
 
 //=============================================================================
 // TestCheckTerminate expects that the provided expression causes process termination
@@ -89,24 +88,45 @@
 // the call stack is not unwinded correctly.
 // You should disable memory leak detection in tests that use TestCheckTerminate.
 //=============================================================================
-#define TestCheckTerminateL(expr, line) \
-  TestAssert::ExpectTerminate([&]() { expr; }, MSO_WIDE_STR("Line: " line " Must terminate: [ " MSO_TO_STR(expr) " ]"))
-#define TestCheckTerminate(expr) TestCheckTerminateL(expr, MSO_LINE_STR)
+#define TestCheckTerminateAtInternal(file, line, expr, exprStr, ...) \
+  TestAssert::ExpectTerminateAt(                                     \
+      file, line, [&]() { expr; }, exprStr, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
+#define TestCheckTerminateAtM(file, line, expr, ...) TestCheckTerminateAtInternal(file, line, expr, #expr, __VA_ARGS__)
+#define TestCheckTerminateAt(file, line, expr) TestCheckTerminateAtInternal(file, line, expr, #expr, "")
+#define TestCheckTerminateM(expr, ...) TestCheckTerminateAtInternal(__FILE__, __LINE__, expr, #expr, __VA_ARGS__)
+#define TestCheckTerminate(expr) TestCheckTerminateAtInternal(__FILE__, __LINE__, expr, #expr, "")
 
 //=============================================================================
 // TestCheckException expects that the provided expression throws an exception.
 //=============================================================================
-#define TestCheckExceptionL(ex, expr, line) \
-  TestAssert::ExpectException<ex>(          \
-      [&]() { expr; }, MSO_WIDE_STR("Line: " line " Must throw: " MSO_TO_STR(ex) " [ " MSO_TO_STR(expr) " ]"))
-#define TestCheckException(ex, expr) TestCheckExceptionL(ex, expr, MSO_LINE_STR)
+#define TestCheckExceptionAtInternal(file, line, ex, expr, exStr, exprStr, ...) \
+  TestAssert::ExpectExceptionAt<ex>(                                            \
+      file,                                                                     \
+      line,                                                                     \
+      [&]() {                                                                   \
+        OACR_POSSIBLE_THROW;                                                    \
+        expr;                                                                   \
+      },                                                                        \
+      exStr,                                                                    \
+      exprStr,                                                                  \
+      TestAssert::FormatMsg("" __VA_ARGS__).c_str())
+#define TestCheckExceptionAtM(file, line, ex, expr, ...) \
+  TestCheckExceptionAtInternal(file, line, ex, expr, #ex, #expr, __VA_ARGS__)
+#define TestCheckExceptionAt(file, line, ex, expr) TestCheckExceptionAtInternal(file, line, ex, expr, #ex, #expr, "")
+#define TestCheckExceptionM(ex, expr, ...) \
+  TestCheckExceptionAtInternal(__FILE__, __LINE__, ex, expr, #ex, #expr, __VA_ARGS__)
+#define TestCheckException(ex, expr) TestCheckExceptionAtInternal(__FILE__, __LINE__, ex, expr, #ex, #expr, "")
 
 //=============================================================================
 // TestCheckNoThrow expects that the provided expression does not throw an exception.
 //=============================================================================
-#define TestCheckNoThrowL(expr, line) \
-  TestAssert::ExpectNoThrow([&]() { expr; }, MSO_WIDE_STR("Line: " line " Must not throw: [ " MSO_TO_STR(expr) " ]"))
-#define TestCheckNoThrow(expr) TestCheckNoThrowL(expr, MSO_LINE_STR)
+#define TestCheckNoThrowAtInternal(file, line, expr, exprStr, ...) \
+  TestAssert::ExpectNoThrowAt(                                     \
+      file, line, [&]() { expr; }, exprStr, TestAssert::FormatMsg("" __VA_ARGS__).c_str())
+#define TestCheckNoThrowAtM(file, line, expr, ...) TestCheckNoThrowAtInternal(file, line, expr, #expr, __VA_ARGS__)
+#define TestCheckNoThrowAt(file, line, expr) TestCheckNoThrowAtInternal(file, line, expr, #expr, "")
+#define TestCheckNoThrowM(expr, ...) TestCheckNoThrowAtInternal(__FILE__, __LINE__, expr, #expr, __VA_ARGS__)
+#define TestCheckNoThrow(expr) TestCheckNoThrowAtInternal(__FILE__, __LINE__, expr, #expr, "")
 
 //=============================================================================
 // TestCheckAssert checks for the code to produce assert with specified tag.
@@ -122,55 +142,5 @@
 // MemoryLeakDetectionHook::TrackPerTest m_trackLeakPerTest;
 //=============================================================================
 #define TEST_DISABLE_MEMORY_LEAK_DETECTION()
-// StopTrackingMemoryAllocations();
-// auto restartTrackingMemoryAllocations = Mso::TCleanup::Make([&]() noexcept { StartTrackingMemoryAllocations(); });
 
-//=============================================================================
-// Helper functions to implement TestCheckTerminate.
-//=============================================================================
-namespace TestAssert {
-
-struct TerminateHandlerRestorer
-{
-  ~TerminateHandlerRestorer() noexcept
-  {
-    std::set_terminate(Handler);
-  }
-
-  std::terminate_handler Handler;
-};
-
-BEGIN_DISABLE_WARNING_FUNCTION_MAY_NOT_CALL_DTOR()
-template <class Fn>
-inline bool ExpectTerminateCore(const Fn& fn)
-{
-  static jmp_buf buf;
-
-  // Set a terminate handler and save the previous terminate handler to be restored in the end of function.
-  TerminateHandlerRestorer terminateRestore = {std::set_terminate([]() { longjmp(buf, 1); })};
-
-  // setjmp originally returns 0, and when longjmp is called it returns 1.
-  if (!setjmp(buf))
-  {
-    fn();
-    return false; // must not be executed if fn() caused termination and the longjmp is executed.
-  }
-  else
-  {
-    return true; // executed if longjmp is executed in the terminate handler.
-  }
-}
-END_DISABLE_WARNING_FUNCTION_MAY_NOT_CALL_DTOR()
-
-template <class Fn>
-inline void ExpectTerminate(const Fn& fn, const WCHAR* message = L"")
-{
-  if (!ExpectTerminateCore(fn))
-  {
-    Fail(message == nullptr || message[0] == L'\0' ? L"Test function did not terminate!" : message);
-  }
-}
-
-} // namespace TestAssert
-
-#endif // TEST_TESTCHECK_H
+#endif // MSO_MOTIFCPP_TESTCHECK_H

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit-disabled": "yarn format"
+      "pre-commit": "yarn format"
     }
   },
   "repository": {


### PR DESCRIPTION
In the https://github.com/microsoft/react-native-windows repo we have adopted the Mso as a source code and did a number of changes there. This PR is the next PR in a series of changes required to bring the changes from the RNW repo and replace Mso there with the one published from this https://github.com/microsoft/Mso repo.

In this PR we update the following liblets:
- guid
- motifCpp