### PR TITLE
[NOT FOR MERGE] See if CI fails on failing unit tests

### DIFF
--- a/change/@microsoft-mso-2020-04-08-14-04-28-MS_TestCIFailure.json
+++ b/change/@microsoft-mso-2020-04-08-14-04-28-MS_TestCIFailure.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Fail a test to see CI behavior",
+  "packageName": "@microsoft/mso",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-04-08T21:04:28.780Z"
+}

--- a/libs/future/tests/executorTest.cpp
+++ b/libs/future/tests/executorTest.cpp
@@ -66,6 +66,7 @@ TEST_CLASS_EX (ExecutorTest, LibletAwareMemLeakDetection)
 
   TEST_METHOD(ThrowingExecutorTestVoidValue)
   {
+    TestCheck(false); // to test CI failuires
     auto queue = MakeTestDispatchQueue();
     auto future = Mso::PostFuture(Mso::Executors::Executor::Throwing{queue}, []() {
                     // We return void


### PR DESCRIPTION
This is just a quick test to see if the CI loop fails if it encounters a failing unit test.
The intentionally has a unit test that fails and it must fail the CI loops.

This PR must not be merged.