### PR TITLE
Update to latest googletest package and fix local tests

### DIFF
--- a/external/gtest/CMakeLists.txt
+++ b/external/gtest/CMakeLists.txt
@@ -14,7 +14,7 @@ if(MSO_ENABLE_UNIT_TESTS)
   FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG        2fe3bd994b3189899d93f1d5a881e725e046fdc2
+    GIT_TAG        7eae8de0da5774fa08ce350d9d470901b76b2834
     GIT_SHALLOW    1
     GIT_PROGRESS   1
   )

--- a/libs/motifCpp/include/motifCpp/motifCppTest.h
+++ b/libs/motifCpp/include/motifCpp/motifCppTest.h
@@ -101,7 +101,7 @@ inline void AreEqualAt(
   GTEST_ASSERT_AT_(
       file,
       line,
-      ::testing::internal::EqHelper<GTEST_IS_NULL_LITERAL_(expected)>::Compare(
+      ::testing::internal::EqHelper::Compare(
           expectedExpr, actualExpr, expected, actual),
       GTEST_FATAL_FAILURE_AT_)
       << FormatCustomMsg(line, message);
@@ -125,7 +125,7 @@ void AreEqualAt(
   GTEST_ASSERT_AT_(
       file,
       line,
-      ::testing::internal::EqHelper<GTEST_IS_NULL_LITERAL_(expected)>::Compare(
+      ::testing::internal::EqHelper::Compare(
           expectedExpr, actualExpr, expected, actual),
       GTEST_FATAL_FAILURE_AT_)
       << FormatCustomMsg(line, message);


### PR DESCRIPTION
This change updates the `GIT_TAG` for the `googletest` external dependency to the latest commit.

To accommodate this update, `motifCppTest.h` is also update to reflect the removal of `GTEST_IS_NULL_LITERAL_(expected)` which is no longer needed. 