### PR TITLE
Fix build break related to fetching GTest sources

### DIFF
--- a/change/@microsoft-mso-2022-02-09-17-01-10-PR-FixGTestBuild.json
+++ b/change/@microsoft-mso-2022-02-09-17-01-10-PR-FixGTestBuild.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix build break related to fetching GTest sources",
+  "packageName": "@microsoft/mso",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2022-02-10T01:01:10.496Z"
+}

--- a/external/gtest/CMakeLists.txt
+++ b/external/gtest/CMakeLists.txt
@@ -13,10 +13,7 @@ if(MSO_ENABLE_UNIT_TESTS)
 
   FetchContent_Declare(
     googletest
-    GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG        7eae8de0da5774fa08ce350d9d470901b76b2834
-    GIT_SHALLOW    1
-    GIT_PROGRESS   1
+    URL https://github.com/google/googletest/archive/06519cedc3159de8b36a504766ad6b7966555f10.zip
   )
 
   FetchContent_GetProperties(googletest)

--- a/libs/motifCpp/include/motifCpp/motifCppTest.h
+++ b/libs/motifCpp/include/motifCpp/motifCppTest.h
@@ -101,8 +101,7 @@ inline void AreEqualAt(
   GTEST_ASSERT_AT_(
       file,
       line,
-      ::testing::internal::EqHelper::Compare(
-          expectedExpr, actualExpr, expected, actual),
+      ::testing::internal::EqHelper::Compare(expectedExpr, actualExpr, expected, actual),
       GTEST_FATAL_FAILURE_AT_)
       << FormatCustomMsg(line, message);
 }
@@ -125,8 +124,7 @@ void AreEqualAt(
   GTEST_ASSERT_AT_(
       file,
       line,
-      ::testing::internal::EqHelper::Compare(
-          expectedExpr, actualExpr, expected, actual),
+      ::testing::internal::EqHelper::Compare(expectedExpr, actualExpr, expected, actual),
       GTEST_FATAL_FAILURE_AT_)
       << FormatCustomMsg(line, message);
 }

--- a/tools/cmake/liblet.cmake
+++ b/tools/cmake/liblet.cmake
@@ -47,8 +47,8 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   set(WIN_TARGET_ARCH $ENV{VSCMD_ARG_TGT_ARCH})
-  if(${WIN_TARGET_ARCH} STREQUAL "")
-    message(FATAL_ERROR "Error: environment variable VSCMD_ARG_TGT_ARCH is not set (required for Windows builds). Are you using a Visual Studio Tools Command Prompt?")
+  if("${WIN_TARGET_ARCH}" STREQUAL "")
+    set(WIN_TARGET_ARCH "x64")
   endif()
 endif()
 


### PR DESCRIPTION
Lately we observe PR build breaks when we fetch GTest sources.
It seems that GitHub does not allow fetching sources by a hashcode.

In this PR we are switching to fetching the ZIP file related to the hash code.
This method is recommended by the GTest docs.
The GTest ZIP file in this PR matches the latest GTest code on 2/8/2022.

Also, there are two other related changes:
- Provide default for the `WIN_TARGET_ARCH` variable in the `linblet.cmake` to enable build in VS Code.
- Automated code formatting of `motifCppTest.h`.
