### PR TITLE
Add new guid methods

### DIFF
--- a/change/@microsoft-mso-2022-04-01-18-01-32-sid-dahiya-AddGuidStringMethods.json
+++ b/change/@microsoft-mso-2022-04-01-18-01-32-sid-dahiya-AddGuidStringMethods.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add new methods to liblet guid",
+  "packageName": "@microsoft/mso",
+  "email": "sidahiy@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2022-04-02T01:01:32.436Z"
+}

--- a/libs/guid/CMakeLists.txt
+++ b/libs/guid/CMakeLists.txt
@@ -4,7 +4,9 @@
 liblet(guid
   DEPENDS
     Mso::compilerAdapters
+    Mso::crash
     Mso::debugAssertApi
+    Mso::memoryApi
     Mso::oacr
     Mso::tagUtils
 )

--- a/libs/guid/include/CMakeLists.txt
+++ b/libs/guid/include/CMakeLists.txt
@@ -3,6 +3,8 @@
 
 liblet_includes(
   INCLUDES
+    guid/comparison.h
     guid/msoGuid.h
     guid/msoGuidDetails.h
+    guid/oguid.h
 )

--- a/libs/guid/include/guid/comparison.h
+++ b/libs/guid/include/guid/comparison.h
@@ -1,0 +1,105 @@
+/*************************************************************************
+Simple namespace to wrap GUID comparisons
+Copyright (C) 2004 Microsoft Corporation
+*************************************************************************/
+#pragma once
+#ifndef MSO_PLATFORMADAPTERS_COMPARISON_H
+#define MSO_PLATFORMADAPTERS_COMPARISON_H
+
+#include <compileradapters/cppmacros.h>
+#include <compileradapters/functiondecorations.h>
+#include <guiddef.h>
+#include <memoryApi/memoryComparison.h>
+#include <utility>
+
+namespace Mso::Guid::MemCompare {
+
+	inline int Compare(const GUID& lhs, const GUID& rhs) noexcept
+	{
+		return Mso::Memory::Compare(lhs, rhs);
+	}
+
+	inline bool Exact(const GUID& lhs, const GUID& rhs) noexcept
+	{
+		return Mso::Memory::Exact(lhs, rhs);
+	}
+
+	inline bool Less(const GUID& lhs, const GUID& rhs) noexcept
+	{
+		return Mso::Memory::Less(lhs, rhs);
+	}
+
+	inline bool LessOrEqual(const GUID& lhs, const GUID& rhs) noexcept
+	{
+		return Mso::Memory::LessOrEqual(lhs, rhs);
+	}
+
+	inline bool More(const GUID& lhs, const GUID& rhs) noexcept
+	{
+		return Mso::Memory::More(lhs, rhs);
+	}
+
+	inline bool MoreOrEqual(const GUID& lhs, const GUID& rhs) noexcept
+	{
+		return Mso::Memory::MoreOrEqual(lhs, rhs);
+	}
+	
+	struct LessFunctor
+	{
+		bool operator()(const GUID& lhs, const GUID& rhs) const noexcept { return Less(lhs, rhs); }
+	};
+} // Mso::Guid::MemCompare
+
+namespace Mso::Guid::LexicalCompare {
+
+	inline int Compare(const GUID& lhs, const GUID& rhs) noexcept
+	{
+		if (lhs.Data1 < rhs.Data1) 
+			return -1; 
+		else if (rhs.Data1 < lhs.Data1) 
+			return 1;
+		if (lhs.Data2 < rhs.Data2) 
+			return -1; 
+		else if (rhs.Data2 < lhs.Data2)
+			return 1;
+		if (lhs.Data3 < rhs.Data3) 
+			return -1; 
+		else if (rhs.Data3 < lhs.Data3) 
+			return 1;
+		for (int i = 0; i < 8; ++i)
+			if (lhs.Data4[i] < rhs.Data4[i]) return -1; else if (rhs.Data4[i] < lhs.Data4[i]) return 1;
+		return 0;
+	}
+
+	inline bool Exact(const GUID& lhs, const GUID& rhs) noexcept
+	{
+		return Compare(lhs, rhs) == 0;
+	}
+
+	inline bool Less(const GUID& lhs, const GUID& rhs) noexcept
+	{
+		return Compare(lhs, rhs) < 0;
+	}
+
+	inline bool LessOrEqual(const GUID& lhs, const GUID& rhs) noexcept
+	{
+		return Compare(lhs, rhs) <= 0;
+	}
+
+	inline bool More(const GUID& lhs, const GUID& rhs) noexcept
+	{
+		return Compare(lhs, rhs) > 0;
+	}
+
+	inline bool MoreOrEqual(const GUID& lhs, const GUID& rhs) noexcept
+	{
+		return Compare(lhs, rhs) >= 0;
+	}
+	
+	struct LessFunctor
+	{
+		bool operator()(const GUID& lhs, const GUID& rhs) const noexcept { return Less(lhs, rhs); }
+	};
+} //Mso::Guid::LexicalCompare
+
+#endif // MSO_PLATFORMADAPTERS_COMPARISON_H

--- a/libs/guid/include/guid/oguid.h
+++ b/libs/guid/include/guid/oguid.h
@@ -206,7 +206,7 @@ inline void UnformattedStringToGUID(const std::wstring& str, GUID& guid)
   StringToGUID(localStr, guid);
 }
 
-inline bool FEmptyGuid(const GUID& guid) noexcept
+inline bool IsEmptyGuid(const GUID& guid) noexcept
 {
   static const GUID emptyGuid = {0, 0, 0, {0, 0, 0, 0, 0, 0, 0, 0}};
   return static_cast<bool>(IsEqualGUID(emptyGuid, guid));

--- a/libs/guid/include/guid/oguid.h
+++ b/libs/guid/include/guid/oguid.h
@@ -1,0 +1,217 @@
+/*************************************************************************
+Simple namespace to wrap GUID generation
+Copyright (C) 2004 Microsoft Corporation
+*************************************************************************/
+#pragma once
+#ifndef MSO_PLATFORMADAPTERS_OGUID_H
+#define MSO_PLATFORMADAPTERS_OGUID_H
+
+#include <codecvt>
+#include <compileradapters/cppmacros.h>
+#include <compileradapters/functiondecorations.h>
+#include <locale>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string_view>
+#include <string>
+
+#ifdef MS_TARGET_WINDOWS
+#include <comBaseApi.h>
+#else
+#include <guiddef.h>
+#endif
+/// <summary>
+/// Helpers for GUIDs
+/// </summary>
+namespace OGuid {
+LIBLET_PUBLICAPI void Create(std::wstring& str, bool noBraces = false) noexcept;
+LIBLET_PUBLICAPI std::wstring Create(bool noBraces) noexcept;
+LIBLET_PUBLICAPI void Create(GUID& pguid) noexcept;
+LIBLET_PUBLICAPI GUID Create() noexcept;
+
+/// <summary>
+/// Convert GUID to guid string format
+/// </summary>
+/// <param name="guid">input guid</param>
+/// <param name="noBraces">if we want no braces (default false)</param>
+/// <returns>guid in string form</returns>
+LIBLET_PUBLICAPI std::wstring ToString(const GUID& guid, bool noBraces = false) noexcept;
+
+/// <summary>
+/// Convert GUID structure to guid string format
+/// </summary>
+/// <param name="guid">input guid</param>
+/// <param name="noBraces">if we want no braces (default false)</param>
+/// <returns>guid in string form</returns>
+inline std::string ToAsciiString(const GUID& guid, bool noBraces = false) noexcept
+{
+  auto str = ToString(guid, noBraces);
+  using convert_type = std::codecvt_utf8<wchar_t>;
+  std::wstring_convert<convert_type, wchar_t> converter;
+  return converter.to_bytes(str);
+}
+
+/// <summary>
+/// Convert GUID structure to guid string format
+/// </summary>
+/// <param name="guid">input guid</param>
+/// <param name="str">output guid string</param>
+/// <param name="noBraces">if we want no braces (default false)</param>
+/// <returns>void</returns>
+/// <remarks></remarks>
+inline void GUIDToString(const GUID& guid, std::wstring& strOut, bool noBraces = false) noexcept
+{
+  auto str = ToString(guid, noBraces);
+  std::swap(str, strOut);
+}
+
+/// <summary>
+/// convert guid string into GUID structure
+/// </summary>
+/// <param name="str">input guid string</param>
+/// <param name="guid">output GUID</param>
+/// <returns>void</returns>
+/// <remarks></remarks>
+/// <exception cref="et::OutOfMemory">memory failure in IIDFromString API</exception>
+/// <exception cref="et::InvalidArgument">bad guid string</exception>
+/// <exception cref="HRESULT">unexpected failure in IIDFromString API</exception>
+inline void StringToGUID(const std::wstring& str, GUID& guid)
+{
+  std::wstring localStr = str;
+  // ensure that the localStr is well formed i.e. GUID is enclosed in {}
+  if (localStr[0] != L'{' && localStr[localStr.length() - 1] != L'}')
+  {
+    std::wstringstream formattedGuidString;
+    formattedGuidString << L"{" << localStr << L"}";
+    localStr = formattedGuidString.str();
+  }
+  HRESULT hr = ::IIDFromString(&localStr[0], &guid);
+  if (hr == E_INVALIDARG)
+  {
+    throw std::invalid_argument("Invalid GUID string");
+  }
+  else if (hr == E_OUTOFMEMORY)
+  {
+    throw std::runtime_error("memory failure converting string to guid");
+  }
+  else if (hr != S_OK)
+  {
+    throw std::exception("Unexpected failure converting string to guid");
+  }
+}
+
+inline GUID StringToGUID(const std::wstring& str)
+{
+  GUID guid{};
+  StringToGUID(str, guid);
+  return guid;
+}
+
+inline GUID StringToGUID(const std::string_view& guidStr)
+{
+  std::wstring wStr(guidStr.data(), guidStr.data() + guidStr.size());
+  return StringToGUID(wStr);
+}
+
+// a const char* member of the overload set is required as long as we provide both basic_string<> and
+// basic_string_view<> due to ambiguous implict construction.  In the future, we should consider if
+// its worth it to collapse this entire space down to basic_string_view<> as the only input parameter.
+// basic_string<> knows how to implicitly convert to basic_string_view<> and basic_string_view<> has
+// a ctor for the CharT* types so the basic_string_view<> type should, in theory, be All We Ever Need (tm)
+inline GUID StringToGUID(const char* guidStr)
+{
+  return StringToGUID(std::string_view(guidStr));
+}
+
+// The wc16* workarounds for wstring_view => wstring don't exist yet
+#if !MS_TARGET_ANDROID && !MS_TARGET_APPLE
+
+inline GUID StringToGUID(const std::wstring_view& guidStr)
+{
+  std::wstring wStr(guidStr);
+  return StringToGUID(wStr);
+}
+
+inline GUID StringToGUID(const wchar_t* guidStr)
+{
+  return StringToGUID(std::wstring_view(guidStr));
+}
+
+#endif
+
+inline std::optional<GUID> TryStringToGUID(const std::wstring& str) noexcept
+{
+  try
+  {
+    return StringToGUID(str);
+  }
+  catch (const std::exception&)
+  {
+    return std::nullopt;
+  }
+}
+
+inline std::optional<GUID> TryStringToGUID(const std::string_view& str) noexcept
+{
+  try
+  {
+    return StringToGUID(str);
+  }
+  catch (const std::exception&)
+  {
+    return std::nullopt;
+  }
+}
+
+#if !MS_TARGET_ANDROID && !MS_TARGET_APPLE
+inline std::optional<GUID> TryStringToGUID(const std::wstring_view& str) noexcept
+{
+  try
+  {
+    return StringToGUID(str);
+  }
+  catch (const std::exception&)
+  {
+    return std::nullopt;
+  }
+}
+#endif
+
+/// <summary>
+/// convert short unformatted guid string (i.e. length 32) into GUID structure
+/// </summary>
+/// <param name="str">input guid string</param>
+/// <param name="guid">output GUID</param>
+/// <returns>void</returns>
+/// <remarks></remarks>
+/// <exception cref="et::OutOfMemory">memory failure in IIDFromString API</exception>
+/// <exception cref="et::InvalidArgument">bad guid string</exception>
+/// <exception cref="HRESULT">unexpected failure in IIDFromString API</exception>
+inline void UnformattedStringToGUID(const std::wstring& str, GUID& guid)
+{
+  std::wstring localStr = str;
+  if (localStr.length() != 32)
+  {
+    throw std::invalid_argument("Invalid unformatted GUID string");
+  }
+  // expand the localStr to be well formed i.e. GUID contains "-"
+  localStr.insert(0, 1, '{');
+  localStr.insert(9, 1, '-');
+  localStr.insert(14, 1, '-');
+  localStr.insert(19, 1, '-');
+  localStr.insert(24, 1, '-');
+  localStr.insert(37, 1, '}');
+
+  StringToGUID(localStr, guid);
+}
+
+inline bool FEmptyGuid(const GUID& guid) noexcept
+{
+  static const GUID emptyGuid = {0, 0, 0, {0, 0, 0, 0, 0, 0, 0, 0}};
+  return static_cast<bool>(IsEqualGUID(emptyGuid, guid));
+}
+
+} // namespace OGuid
+
+#endif // MSO_PLATFORMADAPTERS_OGUID_H

--- a/libs/guid/src/CMakeLists.txt
+++ b/libs/guid/src/CMakeLists.txt
@@ -1,8 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-liblet_tests(
+liblet_sources(
   SOURCES
-    guidTest.cpp
-    oguidTest.cpp
+    oguid.cpp
 )

--- a/libs/guid/src/oguid.cpp
+++ b/libs/guid/src/oguid.cpp
@@ -1,0 +1,70 @@
+/*************************************************************************
+  Simple namespace to wrap GUID generation
+  Copyright (C) 2004 Microsoft Corporation
+*************************************************************************/
+#include <guid/oguid.h>
+#include <guid/msoguid.h>
+#include <crash/verifyElseCrash.h>
+
+const size_t c_cchGUID = 38;
+
+std::wstring OGuid::ToString(const GUID& guid, bool noBraces) noexcept
+{
+  wchar_t wzGuid[c_cchGUID + 1];
+  int cchGuid = ::StringFromGUID2(guid, RgC(wzGuid));
+  VerifyElseCrashSzTag(cchGuid == _countof(wzGuid), "Failed to convert guid?", 0x01114612 /* tag_beuys */);
+
+  const wchar_t* wzGuidStart = wzGuid;
+  const wchar_t* wzGuidEnd = wzGuid + _countof(wzGuid) - 1;
+  if (noBraces)
+  {
+    wzGuidStart++;
+    wzGuidEnd--;
+  }
+
+  return {wzGuidStart, wzGuidEnd};
+}
+
+/// <summary>
+/// Creates a GUID and converts into string
+/// </summary>
+/// <param name="str">string to return guid</param>
+/// <param name="noBraces">if we want braces removed (dafult false)</param>
+/// <returns>void</returns>
+void OGuid::Create(std::wstring& str, bool noBraces) noexcept
+{
+  str = ToString(Create(), noBraces);
+}
+
+/// <summary>
+/// Creates a GUID and converts into string
+/// </summary>
+/// <param name="str">string to return guid</param>
+/// <param name="noBraces">if we want braces removed (dafult false)</param>
+/// <returns>void</returns>
+std::wstring OGuid::Create(bool noBraces) noexcept
+{
+  return ToString(Create(), noBraces);
+}
+
+/// <summary>
+/// Creates a GUID
+/// </summary>
+/// <param name="guid">newly generated  GUID</param>
+/// <returns></returns>
+void OGuid::Create(GUID& guid) noexcept
+{
+  guid = Create();
+}
+
+/// <summary>
+/// Creates a GUID
+/// </summary>
+/// <returns>newly generated  GUID</returns>
+GUID OGuid::Create() noexcept
+{
+  GUID guid{};
+  HRESULT hr = ::CoCreateGuid(&guid);
+  VerifyElseCrashTag(hr == S_OK, 0x0245759c /* tag_crxw2 */);
+  return guid;
+}

--- a/libs/guid/tests/oguidtest.cpp
+++ b/libs/guid/tests/oguidtest.cpp
@@ -4,182 +4,193 @@
 #include <optional>
 
 // {7714B323-69D2-4B37-B6A1-1B433E6EA023}
-const GUID nonNullTestGuid = { 0x7714b323, 0x69d2, 0x4b37, { 0xb6, 0xa1, 0x1b, 0x43, 0x3e, 0x6e, 0xa0, 0x23 } };
+const GUID nonNullTestGuid = {0x7714b323, 0x69d2, 0x4b37, {0xb6, 0xa1, 0x1b, 0x43, 0x3e, 0x6e, 0xa0, 0x23}};
 
-TEST_CLASS(Creation)
+TEST_CLASS (Creation)
 {
-	TEST_METHOD(createstring)
-	{
-		std::wstring str;
-		OGuid::Create(str);
-		TestAssert::IsTrue(38 == str.length()); // guid is 38 characters
-	}
+  TEST_METHOD(createstring)
+  {
+    std::wstring str;
+    OGuid::Create(str);
+    TestAssert::IsTrue(38 == str.length()); // guid is 38 characters
+  }
 
-	TEST_METHOD(createguid)
-	{
-		GUID guid;
-		OGuid::Create(guid);
+  TEST_METHOD(createguid)
+  {
+    GUID guid;
+    OGuid::Create(guid);
 
-		// I'm only doing this to verify the GUID value above,
-		// tho it'll convert anything.
-		const auto str = OGuid::ToString(guid);
-		TestAssert::IsTrue(38 == str.length()); // guid is 38 characters
-	}
+    // I'm only doing this to verify the GUID value above,
+    // tho it'll convert anything.
+    const auto str = OGuid::ToString(guid);
+    TestAssert::IsTrue(38 == str.length()); // guid is 38 characters
+  }
 };
 
-TEST_CLASS(Conversions)
+TEST_CLASS (Conversions)
 {
-	TEST_METHOD(Success_FullForm)
-	{
-		GUID guid;
-		std::wstring validGuidString(L"{BA7709E9-A602-495A-BA29-7E2C69317721}");
-		OGuid::StringToGUID(validGuidString, guid);
-		const auto str = OGuid::ToString(guid);
-		TestAssert::IsTrue(str == validGuidString);
-	}
+  TEST_METHOD(Success_FullForm)
+  {
+    GUID guid;
+    std::wstring validGuidString(L"{BA7709E9-A602-495A-BA29-7E2C69317721}");
+    OGuid::StringToGUID(validGuidString, guid);
+    const auto str = OGuid::ToString(guid);
+    TestAssert::IsTrue(str == validGuidString);
+  }
 
-	TEST_METHOD(Success_UnformattedToGUID)
-	{
-		GUID guid;
-		std::wstring validUnformattedGuidString(L"7714B32369D24B37B6A11B433E6EA023");
-		OGuid::UnformattedStringToGUID(validUnformattedGuidString, guid);
-		TestAssert::IsTrue(guid == nonNullTestGuid);
-	}
+  TEST_METHOD(Success_UnformattedToGUID)
+  {
+    GUID guid;
+    std::wstring validUnformattedGuidString(L"7714B32369D24B37B6A11B433E6EA023");
+    OGuid::UnformattedStringToGUID(validUnformattedGuidString, guid);
+    TestAssert::IsTrue(guid == nonNullTestGuid);
+  }
 
-	TEST_METHOD(Success_UnformattedForm_To_FullForm)
-	{
-		GUID guid;
-		std::wstring validGuidString(L"{BA7709E9-A602-495A-BA29-7E2C69317721}");
-		std::wstring validShortGuidString(L"BA7709E9A602495ABA297E2C69317721");
-		OGuid::UnformattedStringToGUID(validShortGuidString, guid);
-		const auto str = OGuid::ToString(guid);
-		TestAssert::IsTrue(str == validGuidString);
-	}
+  TEST_METHOD(Success_UnformattedForm_To_FullForm)
+  {
+    GUID guid;
+    std::wstring validGuidString(L"{BA7709E9-A602-495A-BA29-7E2C69317721}");
+    std::wstring validShortGuidString(L"BA7709E9A602495ABA297E2C69317721");
+    OGuid::UnformattedStringToGUID(validShortGuidString, guid);
+    const auto str = OGuid::ToString(guid);
+    TestAssert::IsTrue(str == validGuidString);
+  }
 
-	TEST_METHOD(Failure_FullForm)
-	{
-		GUID guid;
-		std::wstring invalidGuidString(L"{BA79E9-A602-495A-BA29-7E2C69317721}");
-		TestAssert::ExpectException<std::exception>([&]() { OGuid::StringToGUID(invalidGuidString, guid); });
-	}
+  TEST_METHOD(Failure_FullForm)
+  {
+    GUID guid;
+    std::wstring invalidGuidString(L"{BA79E9-A602-495A-BA29-7E2C69317721}");
+    TestAssert::ExpectException<std::exception>([&]() { OGuid::StringToGUID(invalidGuidString, guid); });
+  }
 
-	TEST_METHOD(Failure_FullForm_NoExcept)
-	{
-		std::wstring invalidGuidString(L"{BA79E9-A602-495A-BA29-7E2C69317721}");
-		TestAssert::AreEqual(std::nullopt, OGuid::TryStringToGUID(invalidGuidString));
-	}
+  TEST_METHOD(Failure_FullForm_NoExcept)
+  {
+    std::wstring invalidGuidString(L"{BA79E9-A602-495A-BA29-7E2C69317721}");
+    TestAssert::AreEqual(std::nullopt, OGuid::TryStringToGUID(invalidGuidString));
+  }
 
-	TEST_METHOD(Failure_UnformattedForm)
-	{
-		GUID guid;
-		std::wstring invalidGuidString(L"BA79E9A602495ABA297E2C69317721}");
-		TestAssert::ExpectException<std::exception>([&]() { OGuid::UnformattedStringToGUID(invalidGuidString, guid); });
-	}
+  TEST_METHOD(Failure_UnformattedForm)
+  {
+    GUID guid;
+    std::wstring invalidGuidString(L"BA79E9A602495ABA297E2C69317721}");
+    TestAssert::ExpectException<std::exception>([&]() { OGuid::UnformattedStringToGUID(invalidGuidString, guid); });
+  }
 
-	TEST_METHOD(AsciiString)
-	{
-		TestAssert::AreEqual(L"{7714B323-69D2-4B37-B6A1-1B433E6EA023}", OGuid::ToString(nonNullTestGuid).c_str());
-		TestAssert::AreEqual(L"7714B323-69D2-4B37-B6A1-1B433E6EA023", OGuid::ToString(nonNullTestGuid, true).c_str());
-	}
+  TEST_METHOD(AsciiString)
+  {
+    TestAssert::AreEqual(L"{7714B323-69D2-4B37-B6A1-1B433E6EA023}", OGuid::ToString(nonNullTestGuid).c_str());
+    TestAssert::AreEqual(L"7714B323-69D2-4B37-B6A1-1B433E6EA023", OGuid::ToString(nonNullTestGuid, true).c_str());
+  }
 
-	TEST_METHOD(string_view)
-	{
-		std::string_view s { "{7714B323-69D2-4B37-B6A1-1B433E6EA023}" };
-		TestAssert::IsTrue(OGuid::StringToGUID(s) == nonNullTestGuid);
-	}
+  TEST_METHOD(string_view)
+  {
+    std::string_view s{"{7714B323-69D2-4B37-B6A1-1B433E6EA023}"};
+    TestAssert::IsTrue(OGuid::StringToGUID(s) == nonNullTestGuid);
+  }
 
-	TEST_METHOD(WstringView)
-	{
-		std::wstring_view s { L"{7714B323-69D2-4B37-B6A1-1B433E6EA023}" };
-		TestAssert::IsTrue(OGuid::StringToGUID(s) == nonNullTestGuid);
-
-	}
+  TEST_METHOD(WstringView)
+  {
+    std::wstring_view s{L"{7714B323-69D2-4B37-B6A1-1B433E6EA023}"};
+    TestAssert::IsTrue(OGuid::StringToGUID(s) == nonNullTestGuid);
+  }
 };
 
 static void IsSmallerOrEqualTestHelper(const GUID& lhs, const GUID& rhs)
 {
-	bool fIsSmallerEqual = Mso::Guid::LexicalCompare::LessOrEqual( lhs, rhs );
-	wchar_t wzlhs[128]; ::StringFromGUID2(lhs, RgC(wzlhs));
-	wchar_t wzrhs[128]; ::StringFromGUID2(rhs, RgC(wzrhs));
-	TestAssert::AreEqual(fIsSmallerEqual, wcscmp(wzlhs, wzrhs) <= 0);
+  bool fIsSmallerEqual = Mso::Guid::LexicalCompare::LessOrEqual(lhs, rhs);
+  wchar_t wzlhs[128];
+  ::StringFromGUID2(lhs, RgC(wzlhs));
+  wchar_t wzrhs[128];
+  ::StringFromGUID2(rhs, RgC(wzrhs));
+  TestAssert::AreEqual(fIsSmallerEqual, wcscmp(wzlhs, wzrhs) <= 0);
 }
 
-TEST_CLASS(Comparison)
+TEST_CLASS (Comparison)
 {
-	TEST_METHOD(IsSmallerOrEqual)
-	{
-		GUID guid1 = GUID();
-		IsSmallerOrEqualTestHelper(guid1, guid1);
+  TEST_METHOD(IsSmallerOrEqual)
+  {
+    GUID guid1 = GUID();
+    IsSmallerOrEqualTestHelper(guid1, guid1);
 
-		// Data1
-		GUID guid2 = GUID(); guid2.Data1 = 1;
-		IsSmallerOrEqualTestHelper(guid2, guid2);
-		IsSmallerOrEqualTestHelper(guid1, guid2);
-		IsSmallerOrEqualTestHelper(guid2, guid1);
+    // Data1
+    GUID guid2 = GUID();
+    guid2.Data1 = 1;
+    IsSmallerOrEqualTestHelper(guid2, guid2);
+    IsSmallerOrEqualTestHelper(guid1, guid2);
+    IsSmallerOrEqualTestHelper(guid2, guid1);
 
-		// Data2
-		guid2 = GUID(); guid2.Data2 = 1;
-		IsSmallerOrEqualTestHelper(guid2, guid2);
-		IsSmallerOrEqualTestHelper(guid1, guid2);
-		IsSmallerOrEqualTestHelper(guid2, guid1);
+    // Data2
+    guid2 = GUID();
+    guid2.Data2 = 1;
+    IsSmallerOrEqualTestHelper(guid2, guid2);
+    IsSmallerOrEqualTestHelper(guid1, guid2);
+    IsSmallerOrEqualTestHelper(guid2, guid1);
 
-		// Data3
-		guid2 = GUID(); guid2.Data3 = 1;
-		IsSmallerOrEqualTestHelper(guid2, guid2);
-		IsSmallerOrEqualTestHelper(guid1, guid2);
-		IsSmallerOrEqualTestHelper(guid2, guid1);
+    // Data3
+    guid2 = GUID();
+    guid2.Data3 = 1;
+    IsSmallerOrEqualTestHelper(guid2, guid2);
+    IsSmallerOrEqualTestHelper(guid1, guid2);
+    IsSmallerOrEqualTestHelper(guid2, guid1);
 
-		// Data4
-		guid1 = GUID(); guid1.Data4[0] = 1;
-		guid2 = GUID(); guid2.Data4[7] = 1;
-		IsSmallerOrEqualTestHelper(guid2, guid2);
-		IsSmallerOrEqualTestHelper(guid1, guid2);
-		IsSmallerOrEqualTestHelper(guid2, guid1);
+    // Data4
+    guid1 = GUID();
+    guid1.Data4[0] = 1;
+    guid2 = GUID();
+    guid2.Data4[7] = 1;
+    IsSmallerOrEqualTestHelper(guid2, guid2);
+    IsSmallerOrEqualTestHelper(guid1, guid2);
+    IsSmallerOrEqualTestHelper(guid2, guid1);
 
-		guid1 = GUID(); guid1.Data4[6] = 1;
-		guid2 = GUID(); guid2.Data4[7] = 1;
-		IsSmallerOrEqualTestHelper(guid2, guid2);
-		IsSmallerOrEqualTestHelper(guid1, guid2);
-		IsSmallerOrEqualTestHelper(guid2, guid1);
+    guid1 = GUID();
+    guid1.Data4[6] = 1;
+    guid2 = GUID();
+    guid2.Data4[7] = 1;
+    IsSmallerOrEqualTestHelper(guid2, guid2);
+    IsSmallerOrEqualTestHelper(guid1, guid2);
+    IsSmallerOrEqualTestHelper(guid2, guid1);
 
-		guid1 = GUID(); guid1.Data4[5] = 1;
-		guid2 = GUID(); guid2.Data4[6] = 1;
-		IsSmallerOrEqualTestHelper(guid2, guid2);
-		IsSmallerOrEqualTestHelper(guid1, guid2);
-		IsSmallerOrEqualTestHelper(guid2, guid1);
+    guid1 = GUID();
+    guid1.Data4[5] = 1;
+    guid2 = GUID();
+    guid2.Data4[6] = 1;
+    IsSmallerOrEqualTestHelper(guid2, guid2);
+    IsSmallerOrEqualTestHelper(guid1, guid2);
+    IsSmallerOrEqualTestHelper(guid2, guid1);
 
-		OGuid::StringToGUID(std::wstring(L"{314D8A77-3621-4C90-A8AF-DD474202F459}"), guid1);
-		TestAssert::IsTrue(Mso::Guid::LexicalCompare::LessOrEqual(guid1, guid1));
+    OGuid::StringToGUID(std::wstring(L"{314D8A77-3621-4C90-A8AF-DD474202F459}"), guid1);
+    TestAssert::IsTrue(Mso::Guid::LexicalCompare::LessOrEqual(guid1, guid1));
 
-		OGuid::StringToGUID(std::wstring(L"{D8F856B9-B319-4B84-AE21-2EC2381DFF81}"), guid2);
-		IsSmallerOrEqualTestHelper(guid2, guid2);
-		IsSmallerOrEqualTestHelper(guid1, guid2);
-		IsSmallerOrEqualTestHelper(guid2, guid1);
-		TestAssert::IsTrue( Mso::Guid::LexicalCompare::LessOrEqual(guid1, guid2));
+    OGuid::StringToGUID(std::wstring(L"{D8F856B9-B319-4B84-AE21-2EC2381DFF81}"), guid2);
+    IsSmallerOrEqualTestHelper(guid2, guid2);
+    IsSmallerOrEqualTestHelper(guid1, guid2);
+    IsSmallerOrEqualTestHelper(guid2, guid1);
+    TestAssert::IsTrue(Mso::Guid::LexicalCompare::LessOrEqual(guid1, guid2));
 
-		guid1 = guid2;
-		OGuid::StringToGUID(std::wstring(L"{F9C8B96E-84DD-4DBC-9C72-277C6B9CCA0E}"), guid2);
-		IsSmallerOrEqualTestHelper(guid2, guid2);
-		IsSmallerOrEqualTestHelper(guid1, guid2);
-		IsSmallerOrEqualTestHelper(guid2, guid1);
-		TestAssert::IsTrue(Mso::Guid::LexicalCompare::LessOrEqual(guid1, guid2));
+    guid1 = guid2;
+    OGuid::StringToGUID(std::wstring(L"{F9C8B96E-84DD-4DBC-9C72-277C6B9CCA0E}"), guid2);
+    IsSmallerOrEqualTestHelper(guid2, guid2);
+    IsSmallerOrEqualTestHelper(guid1, guid2);
+    IsSmallerOrEqualTestHelper(guid2, guid1);
+    TestAssert::IsTrue(Mso::Guid::LexicalCompare::LessOrEqual(guid1, guid2));
 
-		guid1 = guid2;
-		OGuid::StringToGUID(std::wstring(L"{FCC58B10-9BA4-4872-B77A-600747BF6F17}"), guid2);
-		IsSmallerOrEqualTestHelper(guid2, guid2);
-		IsSmallerOrEqualTestHelper(guid1, guid2);
-		IsSmallerOrEqualTestHelper(guid2, guid1);
-		TestAssert::IsTrue(Mso::Guid::LexicalCompare::LessOrEqual(guid1, guid2));
-	}
+    guid1 = guid2;
+    OGuid::StringToGUID(std::wstring(L"{FCC58B10-9BA4-4872-B77A-600747BF6F17}"), guid2);
+    IsSmallerOrEqualTestHelper(guid2, guid2);
+    IsSmallerOrEqualTestHelper(guid1, guid2);
+    IsSmallerOrEqualTestHelper(guid2, guid1);
+    TestAssert::IsTrue(Mso::Guid::LexicalCompare::LessOrEqual(guid1, guid2));
+  }
 
-	TEST_METHOD(IsEmpty)
-	{
-		GUID guid1 = {};
-		TestAssert::IsTrue(guid1 == GUID_NULL);
-		TestAssert::IsTrue(OGuid::FEmptyGuid(guid1));
+  TEST_METHOD(IsEmpty)
+  {
+    GUID guid1 = {};
+    TestAssert::IsTrue(guid1 == GUID_NULL);
+    TestAssert::IsTrue(OGuid::IsEmptyGuid(guid1));
 
-		GUID guid2 = GUID(); guid2.Data1 = 1;
-		TestAssert::IsFalse(guid2 == GUID_NULL);
-		TestAssert::IsFalse(OGuid::FEmptyGuid(guid2));
-	}
+    GUID guid2 = GUID();
+    guid2.Data1 = 1;
+    TestAssert::IsFalse(guid2 == GUID_NULL);
+    TestAssert::IsFalse(OGuid::IsEmptyGuid(guid2));
+  }
 };

--- a/libs/guid/tests/oguidtest.cpp
+++ b/libs/guid/tests/oguidtest.cpp
@@ -1,0 +1,185 @@
+#include "motifcpp/motifcpptest.h"
+#include <guid/comparison.h>
+#include <guid/OGuid.h>
+#include <optional>
+
+// {7714B323-69D2-4B37-B6A1-1B433E6EA023}
+const GUID nonNullTestGuid = { 0x7714b323, 0x69d2, 0x4b37, { 0xb6, 0xa1, 0x1b, 0x43, 0x3e, 0x6e, 0xa0, 0x23 } };
+
+TEST_CLASS(Creation)
+{
+	TEST_METHOD(createstring)
+	{
+		std::wstring str;
+		OGuid::Create(str);
+		TestAssert::IsTrue(38 == str.length()); // guid is 38 characters
+	}
+
+	TEST_METHOD(createguid)
+	{
+		GUID guid;
+		OGuid::Create(guid);
+
+		// I'm only doing this to verify the GUID value above,
+		// tho it'll convert anything.
+		const auto str = OGuid::ToString(guid);
+		TestAssert::IsTrue(38 == str.length()); // guid is 38 characters
+	}
+};
+
+TEST_CLASS(Conversions)
+{
+	TEST_METHOD(Success_FullForm)
+	{
+		GUID guid;
+		std::wstring validGuidString(L"{BA7709E9-A602-495A-BA29-7E2C69317721}");
+		OGuid::StringToGUID(validGuidString, guid);
+		const auto str = OGuid::ToString(guid);
+		TestAssert::IsTrue(str == validGuidString);
+	}
+
+	TEST_METHOD(Success_UnformattedToGUID)
+	{
+		GUID guid;
+		std::wstring validUnformattedGuidString(L"7714B32369D24B37B6A11B433E6EA023");
+		OGuid::UnformattedStringToGUID(validUnformattedGuidString, guid);
+		TestAssert::IsTrue(guid == nonNullTestGuid);
+	}
+
+	TEST_METHOD(Success_UnformattedForm_To_FullForm)
+	{
+		GUID guid;
+		std::wstring validGuidString(L"{BA7709E9-A602-495A-BA29-7E2C69317721}");
+		std::wstring validShortGuidString(L"BA7709E9A602495ABA297E2C69317721");
+		OGuid::UnformattedStringToGUID(validShortGuidString, guid);
+		const auto str = OGuid::ToString(guid);
+		TestAssert::IsTrue(str == validGuidString);
+	}
+
+	TEST_METHOD(Failure_FullForm)
+	{
+		GUID guid;
+		std::wstring invalidGuidString(L"{BA79E9-A602-495A-BA29-7E2C69317721}");
+		TestAssert::ExpectException<std::exception>([&]() { OGuid::StringToGUID(invalidGuidString, guid); });
+	}
+
+	TEST_METHOD(Failure_FullForm_NoExcept)
+	{
+		std::wstring invalidGuidString(L"{BA79E9-A602-495A-BA29-7E2C69317721}");
+		TestAssert::AreEqual(std::nullopt, OGuid::TryStringToGUID(invalidGuidString));
+	}
+
+	TEST_METHOD(Failure_UnformattedForm)
+	{
+		GUID guid;
+		std::wstring invalidGuidString(L"BA79E9A602495ABA297E2C69317721}");
+		TestAssert::ExpectException<std::exception>([&]() { OGuid::UnformattedStringToGUID(invalidGuidString, guid); });
+	}
+
+	TEST_METHOD(AsciiString)
+	{
+		TestAssert::AreEqual(L"{7714B323-69D2-4B37-B6A1-1B433E6EA023}", OGuid::ToString(nonNullTestGuid).c_str());
+		TestAssert::AreEqual(L"7714B323-69D2-4B37-B6A1-1B433E6EA023", OGuid::ToString(nonNullTestGuid, true).c_str());
+	}
+
+	TEST_METHOD(string_view)
+	{
+		std::string_view s { "{7714B323-69D2-4B37-B6A1-1B433E6EA023}" };
+		TestAssert::IsTrue(OGuid::StringToGUID(s) == nonNullTestGuid);
+	}
+
+	TEST_METHOD(WstringView)
+	{
+		std::wstring_view s { L"{7714B323-69D2-4B37-B6A1-1B433E6EA023}" };
+		TestAssert::IsTrue(OGuid::StringToGUID(s) == nonNullTestGuid);
+
+	}
+};
+
+static void IsSmallerOrEqualTestHelper(const GUID& lhs, const GUID& rhs)
+{
+	bool fIsSmallerEqual = Mso::Guid::LexicalCompare::LessOrEqual( lhs, rhs );
+	wchar_t wzlhs[128]; ::StringFromGUID2(lhs, RgC(wzlhs));
+	wchar_t wzrhs[128]; ::StringFromGUID2(rhs, RgC(wzrhs));
+	TestAssert::AreEqual(fIsSmallerEqual, wcscmp(wzlhs, wzrhs) <= 0);
+}
+
+TEST_CLASS(Comparison)
+{
+	TEST_METHOD(IsSmallerOrEqual)
+	{
+		GUID guid1 = GUID();
+		IsSmallerOrEqualTestHelper(guid1, guid1);
+
+		// Data1
+		GUID guid2 = GUID(); guid2.Data1 = 1;
+		IsSmallerOrEqualTestHelper(guid2, guid2);
+		IsSmallerOrEqualTestHelper(guid1, guid2);
+		IsSmallerOrEqualTestHelper(guid2, guid1);
+
+		// Data2
+		guid2 = GUID(); guid2.Data2 = 1;
+		IsSmallerOrEqualTestHelper(guid2, guid2);
+		IsSmallerOrEqualTestHelper(guid1, guid2);
+		IsSmallerOrEqualTestHelper(guid2, guid1);
+
+		// Data3
+		guid2 = GUID(); guid2.Data3 = 1;
+		IsSmallerOrEqualTestHelper(guid2, guid2);
+		IsSmallerOrEqualTestHelper(guid1, guid2);
+		IsSmallerOrEqualTestHelper(guid2, guid1);
+
+		// Data4
+		guid1 = GUID(); guid1.Data4[0] = 1;
+		guid2 = GUID(); guid2.Data4[7] = 1;
+		IsSmallerOrEqualTestHelper(guid2, guid2);
+		IsSmallerOrEqualTestHelper(guid1, guid2);
+		IsSmallerOrEqualTestHelper(guid2, guid1);
+
+		guid1 = GUID(); guid1.Data4[6] = 1;
+		guid2 = GUID(); guid2.Data4[7] = 1;
+		IsSmallerOrEqualTestHelper(guid2, guid2);
+		IsSmallerOrEqualTestHelper(guid1, guid2);
+		IsSmallerOrEqualTestHelper(guid2, guid1);
+
+		guid1 = GUID(); guid1.Data4[5] = 1;
+		guid2 = GUID(); guid2.Data4[6] = 1;
+		IsSmallerOrEqualTestHelper(guid2, guid2);
+		IsSmallerOrEqualTestHelper(guid1, guid2);
+		IsSmallerOrEqualTestHelper(guid2, guid1);
+
+		OGuid::StringToGUID(std::wstring(L"{314D8A77-3621-4C90-A8AF-DD474202F459}"), guid1);
+		TestAssert::IsTrue(Mso::Guid::LexicalCompare::LessOrEqual(guid1, guid1));
+
+		OGuid::StringToGUID(std::wstring(L"{D8F856B9-B319-4B84-AE21-2EC2381DFF81}"), guid2);
+		IsSmallerOrEqualTestHelper(guid2, guid2);
+		IsSmallerOrEqualTestHelper(guid1, guid2);
+		IsSmallerOrEqualTestHelper(guid2, guid1);
+		TestAssert::IsTrue( Mso::Guid::LexicalCompare::LessOrEqual(guid1, guid2));
+
+		guid1 = guid2;
+		OGuid::StringToGUID(std::wstring(L"{F9C8B96E-84DD-4DBC-9C72-277C6B9CCA0E}"), guid2);
+		IsSmallerOrEqualTestHelper(guid2, guid2);
+		IsSmallerOrEqualTestHelper(guid1, guid2);
+		IsSmallerOrEqualTestHelper(guid2, guid1);
+		TestAssert::IsTrue(Mso::Guid::LexicalCompare::LessOrEqual(guid1, guid2));
+
+		guid1 = guid2;
+		OGuid::StringToGUID(std::wstring(L"{FCC58B10-9BA4-4872-B77A-600747BF6F17}"), guid2);
+		IsSmallerOrEqualTestHelper(guid2, guid2);
+		IsSmallerOrEqualTestHelper(guid1, guid2);
+		IsSmallerOrEqualTestHelper(guid2, guid1);
+		TestAssert::IsTrue(Mso::Guid::LexicalCompare::LessOrEqual(guid1, guid2));
+	}
+
+	TEST_METHOD(IsEmpty)
+	{
+		GUID guid1 = {};
+		TestAssert::IsTrue(guid1 == GUID_NULL);
+		TestAssert::IsTrue(OGuid::FEmptyGuid(guid1));
+
+		GUID guid2 = GUID(); guid2.Data1 = 1;
+		TestAssert::IsFalse(guid2 == GUID_NULL);
+		TestAssert::IsFalse(OGuid::FEmptyGuid(guid2));
+	}
+};

--- a/libs/memoryApi/include/CMakeLists.txt
+++ b/libs/memoryApi/include/CMakeLists.txt
@@ -5,5 +5,6 @@ liblet_includes(
   INCLUDES
     memoryApi/leakDetection.h
     memoryApi/memoryApi.h
+    memoryApi/memoryComparison.h
     memoryApi/memoryLeakScope.h
 )

--- a/libs/memoryApi/include/memoryApi/memoryComparison.h
+++ b/libs/memoryApi/include/memoryApi/memoryComparison.h
@@ -1,0 +1,62 @@
+/**
+  Include this file to get templetized memory based comparisons, including
+  templetized Functors which are handy with STL containers.
+*/
+
+#pragma once
+#ifndef MSO_PLATFORMADAPTERS_MEMORY_COMPARISON_H
+#define MSO_PLATFORMADAPTERS_MEMORY_COMPARISON_H
+
+#include <memory>
+
+namespace Mso::Memory {
+template <typename T>
+int Compare(const T& lhs, const T& rhs) noexcept
+{
+  return memcmp(
+      static_cast<const void*>(std::addressof(lhs)), static_cast<const void*>(std::addressof(rhs)), sizeof(T));
+}
+
+template <typename T>
+bool Exact(const T& lhs, const T& rhs) noexcept
+{
+  return (Mso::Memory::Compare<T>(lhs, rhs) == 0);
+}
+
+template <typename T>
+bool Less(const T& lhs, const T& rhs) noexcept
+{
+  return (Mso::Memory::Compare<T>(lhs, rhs) < 0);
+}
+
+template <typename T>
+bool LessOrEqual(const T& lhs, const T& rhs) noexcept
+{
+  return (Mso::Memory::Compare<T>(lhs, rhs) <= 0);
+}
+
+template <typename T>
+bool More(const T& lhs, const T& rhs) noexcept
+{
+  return (Mso::Memory::Compare<T>(lhs, rhs) > 0);
+}
+
+template <typename T>
+bool MoreOrEqual(const T& lhs, const T& rhs) noexcept
+{
+  return (Mso::Memory::Compare<T>(lhs, rhs) >= 0);
+}
+
+template <typename T>
+class LessFunctor
+{
+public:
+  bool operator()(const T& lhs, const T& rhs) const noexcept
+  {
+    return Mso::Memory::Less<T>(lhs, rhs);
+  }
+};
+
+} // namespace Mso::Memory
+
+#endif // MSO_PLATFORMADAPTERS_MEMORY_COMPARISON_H


### PR DESCRIPTION
This change adds a few `GUID` methods involving `string` operations. Primarily, this change is introducing:
- `ToString`: This method allows converting a `GUID` to wide-string, with or without braces.
- `ToAsciiString`: This method allows converting a `GUID` to narrow-string, with or without braces.
- `StringToGUID`: This method converts a string containing a `GUID` to wide-string.
- `TryStringToGUID`: This method attempts to convert the given `string` to a `GUID`, failing which it returns a `std::nullopt`.
- `UnformattedStringToGUID`: This method converts short, unformatted `GUID` string or length 32 into a `GUID` structure.
- `IsEmptyGuid`: This method checks if the given string is empty.
- `Create`: A few Create methods that allow creating a `GUID` object or a `std::wstring` with a `GUID`.