### PR TITLE
Bump clang-format to 1.8 to address CVE in async

### DIFF
--- a/change/@microsoft-mso-28c1076c-5201-4e9c-b35f-840a49c0a33f.json
+++ b/change/@microsoft-mso-28c1076c-5201-4e9c-b35f-840a49c0a33f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump clang-format to 1.8 to address CVE in async",
+  "packageName": "@microsoft/mso",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/libs/compilerAdapters/include/compilerAdapters/linker.h
+++ b/libs/compilerAdapters/include/compilerAdapters/linker.h
@@ -15,8 +15,10 @@
   be included. Then, add the corresponding MSO_LINK_SYMBOL macro to one of the
   source files that gets compiled directly into your binary (as an *.obj file)
 */
-#define MSO_DEFINE_SYMBOL(symbol) \
-  extern "C" void __cdecl symbol() {}
+#define MSO_DEFINE_SYMBOL(symbol)  \
+  extern "C" void __cdecl symbol() \
+  {                                \
+  }
 
 // MSO_LINK_INCLUDE and MSO_LINK_SYMBOL macros are only needed for MSVC.
 #if MS_TARGET_WINDOWS

--- a/libs/cppExtensions/include/cppExtensions/stringLiteral.h
+++ b/libs/cppExtensions/include/cppExtensions/stringLiteral.h
@@ -33,7 +33,7 @@ template <typename char_type>
 class StringLiteral
 {
 public:
-  constexpr operator _Null_terminated_ const char_type *() const noexcept
+  constexpr operator _Null_terminated_ const char_type*() const noexcept
   {
     return m_string;
   }

--- a/libs/eventWaitHandle/src/eventWaitHandleImpl_posix.cpp
+++ b/libs/eventWaitHandle/src/eventWaitHandleImpl_posix.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-//#include "precomp.h"
+// #include "precomp.h"
 #include "eventWaitHandleImpl.h"
 #include <pthread.h>
 

--- a/libs/eventWaitHandle/src/eventWaitHandleImpl_win.cpp
+++ b/libs/eventWaitHandle/src/eventWaitHandleImpl_win.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-//#include "precomp.h"
+// #include "precomp.h"
 #include "EventWaitHandleImpl.h"
 #include <synchapi.h>
 #include <algorithm>

--- a/libs/future/include/future/details/ifuture.h
+++ b/libs/future/include/future/details/ifuture.h
@@ -75,7 +75,7 @@ struct IFuture : IUnknown
   virtual void AddContinuation(Mso::CntPtr<IFuture>&& continuation) noexcept = 0;
 
   _Success_(
-      return ) virtual bool TryStartSetValue(_Out_ ByteArrayView& valueBuffer, bool crashIfFailed = false) noexcept = 0;
+      return) virtual bool TryStartSetValue(_Out_ ByteArrayView& valueBuffer, bool crashIfFailed = false) noexcept = 0;
   virtual void Post() noexcept = 0;
   virtual void StartAwaiting() noexcept = 0;
   virtual bool TrySetSuccess(bool crashIfFailed = false) noexcept = 0;

--- a/libs/future/include/future/details/resultTraits.h
+++ b/libs/future/include/future/details/resultTraits.h
@@ -84,8 +84,8 @@ struct GetResultTraits<TFutureValue, TExecutor, TCallback, CallbackArgKind::Mayb
 {
   using Type = ResultTraits<
       TFutureValue,
-      decltype(
-          std::declval<TExecutor>().Invoke(std::declval<TCallback>(), std::declval<Mso::Maybe<TFutureValue>&&>()))>;
+      decltype(std::declval<TExecutor>()
+                   .Invoke(std::declval<TCallback>(), std::declval<Mso::Maybe<TFutureValue>&&>()))>;
   static_assert(
       noexcept(std::declval<TExecutor>().Invoke(std::declval<TCallback>(), std::declval<Mso::Maybe<TFutureValue>&&>())),
       "Executor's Invoke method must not throw");

--- a/libs/future/src/futureImpl.h
+++ b/libs/future/src/futureImpl.h
@@ -230,7 +230,7 @@ public:
   void AddContinuation(Mso::CntPtr<IFuture>&& continuation) noexcept override;
 
   _Success_(
-      return ) bool TryStartSetValue(_Out_ ByteArrayView& valueBuffer, bool crashIfFailed = false) noexcept override;
+      return) bool TryStartSetValue(_Out_ ByteArrayView& valueBuffer, bool crashIfFailed = false) noexcept override;
   void Post() noexcept override;
   void StartAwaiting() noexcept override;
   bool TrySetSuccess(bool crashIfFailed = false) noexcept override;

--- a/libs/guid/include/guid/msoGuidDetails.h
+++ b/libs/guid/include/guid/msoGuidDetails.h
@@ -16,7 +16,7 @@ See the msoGuid.h for the usage guidelines.
 #endif
 
 // Clang compiler must target C++11 or up to support MSO*GUIDs because we rely on constexpr.
-//#if (__cplusplus >= 201103L) && !defined(MSO_GUID_DISABLED)
+// #if (__cplusplus >= 201103L) && !defined(MSO_GUID_DISABLED)
 
 #include <compilerAdapters/compilerFeatures.h>
 #include <compilerAdapters/compilerWarnings.h>

--- a/libs/memoryApi/include/memoryApi/memoryApi.h
+++ b/libs/memoryApi/include/memoryApi/memoryApi.h
@@ -83,7 +83,7 @@ enum Enum : unsigned int
   // track this memory using memory marking / idle time leak detection
   MarkingLeak = 0x0004,
 };
-}
+} // namespace AllocFlags
 
 /**
 Return a new allocation of the requested size (cb)

--- a/libs/motifCpp/include/motifCpp/testInfo.h
+++ b/libs/motifCpp/include/motifCpp/testInfo.h
@@ -9,33 +9,39 @@
 #include <vector>
 #include "motifCpp/motifCppTestBase.h"
 
-#define TEST_CLASS(className)                                                                      \
-  struct className;                                                                                \
-                                                                                                   \
-  struct TestClassInfo_##className final                                                           \
-      : Mso::UnitTests::Internal::TestClassInfoReg<TestClassInfo_##className, className>           \
-  {                                                                                                \
-    TestClassInfo_##className() noexcept : TestClassInfoRegType{#className, __FILE__, __LINE__} {} \
-  };                                                                                               \
-                                                                                                   \
+#define TEST_CLASS(className)                                                                   \
+  struct className;                                                                             \
+                                                                                                \
+  struct TestClassInfo_##className final                                                        \
+      : Mso::UnitTests::Internal::TestClassInfoReg<TestClassInfo_##className, className>        \
+  {                                                                                             \
+    TestClassInfo_##className() noexcept : TestClassInfoRegType{#className, __FILE__, __LINE__} \
+    {                                                                                           \
+    }                                                                                           \
+  };                                                                                            \
+                                                                                                \
   struct className : Mso::UnitTests::Internal::TestClassBase<className, TestClassInfo_##className>
 
-#define TEST_CLASS_EX(className, baseClass)                                                                     \
-  struct className;                                                                                             \
-                                                                                                                \
-  struct TestClassInfo_##className final                                                                        \
-      : baseClass                                                                                               \
-      , Mso::UnitTests::Internal::TestClassInfoReg<TestClassInfo_##className, className>                        \
-  {                                                                                                             \
-    TestClassInfo_##className() noexcept : baseClass{}, TestClassInfoRegType{#className, __FILE__, __LINE__} {} \
-  };                                                                                                            \
-                                                                                                                \
+#define TEST_CLASS_EX(className, baseClass)                                                                  \
+  struct className;                                                                                          \
+                                                                                                             \
+  struct TestClassInfo_##className final                                                                     \
+      : baseClass                                                                                            \
+      , Mso::UnitTests::Internal::TestClassInfoReg<TestClassInfo_##className, className>                     \
+  {                                                                                                          \
+    TestClassInfo_##className() noexcept : baseClass{}, TestClassInfoRegType{#className, __FILE__, __LINE__} \
+    {                                                                                                        \
+    }                                                                                                        \
+  };                                                                                                         \
+                                                                                                             \
   struct className : Mso::UnitTests::Internal::TestClassBase<className, TestClassInfo_##className>
 
 #define TEST_METHOD(methodName)                                                                                       \
   struct TestMethodInfo_##methodName final : Mso::UnitTests::Internal::TestMethodInfoReg<TestMethodInfo_##methodName> \
   {                                                                                                                   \
-    TestMethodInfo_##methodName() : TestMethodInfoRegType{TestClassInfoType::Instance, #methodName, __LINE__} {}      \
+    TestMethodInfo_##methodName() : TestMethodInfoRegType{TestClassInfoType::Instance, #methodName, __LINE__}         \
+    {                                                                                                                 \
+    }                                                                                                                 \
                                                                                                                       \
     void Invoke(Mso::UnitTests::TestClass& test) const override                                                       \
     {                                                                                                                 \

--- a/libs/motifCpp/tests/motifCppTest.cpp
+++ b/libs/motifCpp/tests/motifCppTest.cpp
@@ -5,7 +5,7 @@
 #include "motifCpp/testCheck.h"
 
 // Uncomment to see errors
-//#define MOTIF_TEST_SHOW_ERRORS
+// #define MOTIF_TEST_SHOW_ERRORS
 
 TEST_CLASS (MotifCppTest)
 {

--- a/libs/oacr/include/oacr/oacrsal.h
+++ b/libs/oacr/include/oacr/oacrsal.h
@@ -112,79 +112,79 @@
 #define _Pre_opt_tz_ \
   _Pre1_impl_(__maybenull_impl_notref) _Pre1_impl_(__zterm_impl) _Pre_valid_impl_ _$STR_TYPE(_$preTZStr)
 
-#define _Pre_t_cap_(size)                                                               \
-  _Pre1_impl_(__notnull_impl_notref) _Pre2_impl_(__count_x_impl([0]), __cap_impl(size)) \
-      _Pre_valid_impl_ _$STR_TYPE(_$preTStr)
-#define _Pre_opt_t_cap_(size)                                                             \
-  _Pre1_impl_(__maybenull_impl_notref) _Pre2_impl_(__count_x_impl([0]), __cap_impl(size)) \
-      _Pre_valid_impl_ _$STR_TYPE(_$preTStr)
-#define _Pre_t_bytecap_(size)                                                               \
-  _Pre1_impl_(__notnull_impl_notref) _Pre2_impl_(__count_x_impl([0]), __bytecap_impl(size)) \
-      _Pre_valid_impl_ _$STR_TYPE(_$preTStr)
-#define _Pre_opt_t_bytecap_(size)                                                             \
-  _Pre1_impl_(__maybenull_impl_notref) _Pre2_impl_(__count_x_impl([0]), __bytecap_impl(size)) \
-      _Pre_valid_impl_ _$STR_TYPE(_$preTStr)
+#define _Pre_t_cap_(size)                                                                                            \
+  _Pre1_impl_(__notnull_impl_notref) _Pre2_impl_(__count_x_impl([0]), __cap_impl(size)) _Pre_valid_impl_ _$STR_TYPE( \
+      _$preTStr)
+#define _Pre_opt_t_cap_(size)                                                                                          \
+  _Pre1_impl_(__maybenull_impl_notref) _Pre2_impl_(__count_x_impl([0]), __cap_impl(size)) _Pre_valid_impl_ _$STR_TYPE( \
+      _$preTStr)
+#define _Pre_t_bytecap_(size)                                                                                \
+  _Pre1_impl_(__notnull_impl_notref) _Pre2_impl_(__count_x_impl([0]), __bytecap_impl(size)) _Pre_valid_impl_ \
+  _$STR_TYPE(_$preTStr)
+#define _Pre_opt_t_bytecap_(size)                                                                              \
+  _Pre1_impl_(__maybenull_impl_notref) _Pre2_impl_(__count_x_impl([0]), __bytecap_impl(size)) _Pre_valid_impl_ \
+  _$STR_TYPE(_$preTStr)
 #define _Pre_tz_cap_(size) \
   _Pre1_impl_(__notnull_impl_notref) _Pre2_impl_(__zterm_impl, __cap_impl(size)) _Pre_valid_impl_ _$STR_TYPE(_$preTZStr)
-#define _Pre_opt_tz_cap_(size)                                                     \
-  _Pre1_impl_(__maybenull_impl_notref) _Pre2_impl_(__zterm_impl, __cap_impl(size)) \
-      _Pre_valid_impl_ _$STR_TYPE(_$preTZStr)
-#define _Pre_tz_bytecap_(size)                                                       \
-  _Pre1_impl_(__notnull_impl_notref) _Pre2_impl_(__zterm_impl, __bytecap_impl(size)) \
-      _Pre_valid_impl_ _$STR_TYPE(_$preTZStr)
-#define _Pre_opt_tz_bytecap_(size)                                                     \
-  _Pre1_impl_(__maybenull_impl_notref) _Pre2_impl_(__zterm_impl, __bytecap_impl(size)) \
-      _Pre_valid_impl_ _$STR_TYPE(_$preTZStr)
+#define _Pre_opt_tz_cap_(size)                                                                                  \
+  _Pre1_impl_(__maybenull_impl_notref) _Pre2_impl_(__zterm_impl, __cap_impl(size)) _Pre_valid_impl_ _$STR_TYPE( \
+      _$preTZStr)
+#define _Pre_tz_bytecap_(size)                                                                                    \
+  _Pre1_impl_(__notnull_impl_notref) _Pre2_impl_(__zterm_impl, __bytecap_impl(size)) _Pre_valid_impl_ _$STR_TYPE( \
+      _$preTZStr)
+#define _Pre_opt_tz_bytecap_(size)                                                                                  \
+  _Pre1_impl_(__maybenull_impl_notref) _Pre2_impl_(__zterm_impl, __bytecap_impl(size)) _Pre_valid_impl_ _$STR_TYPE( \
+      _$preTZStr)
 
-#define _Pre_t_cap_c_(size)                                                               \
-  _Pre1_impl_(__notnull_impl_notref) _Pre2_impl_(__count_x_impl([0]), __cap_c_impl(size)) \
-      _Pre_valid_impl_ _$STR_TYPE(_$preTStr)
-#define _Pre_opt_t_cap_c_(size)                                                             \
-  _Pre1_impl_(__maybenull_impl_notref) _Pre2_impl_(__count_x_impl([0]), __cap_c_impl(size)) \
-      _Pre_valid_impl_ _$STR_TYPE(_$preTStr)
-#define _Pre_t_bytecap_c_(size)                                                               \
-  _Pre1_impl_(__notnull_impl_notref) _Pre2_impl_(__count_x_impl([0]), __bytecap_c_impl(size)) \
-      _Pre_valid_impl_ _$STR_TYPE(_$preTStr)
-#define _Pre_opt_t_bytecap_c_(size)                                                             \
-  _Pre1_impl_(__maybenull_impl_notref) _Pre2_impl_(__count_x_impl([0]), __bytecap_c_impl(size)) \
-      _Pre_valid_impl_ _$STR_TYPE(_$preTStr)
-#define _Pre_tz_cap_c_(size)                                                       \
-  _Pre1_impl_(__notnull_impl_notref) _Pre2_impl_(__zterm_impl, __cap_c_impl(size)) \
-      _Pre_valid_impl_ _$STR_TYPE(_$preTZStr)
-#define _Pre_opt_tz_cap_c_(size)                                                     \
-  _Pre1_impl_(__maybenull_impl_notref) _Pre2_impl_(__zterm_impl, __cap_c_impl(size)) \
-      _Pre_valid_impl_ _$STR_TYPE(_$preTZStr)
-#define _Pre_tz_bytecap_c_(size)                                                       \
-  _Pre1_impl_(__notnull_impl_notref) _Pre2_impl_(__zterm_impl, __bytecap_c_impl(size)) \
-      _Pre_valid_impl_ _$STR_TYPE(_$preTZStr)
-#define _Pre_opt_tz_bytecap_c_(size)                                                     \
-  _Pre1_impl_(__maybenull_impl_notref) _Pre2_impl_(__zterm_impl, __bytecap_c_impl(size)) \
-      _Pre_valid_impl_ _$STR_TYPE(_$preTZStr)
+#define _Pre_t_cap_c_(size)                                                                                            \
+  _Pre1_impl_(__notnull_impl_notref) _Pre2_impl_(__count_x_impl([0]), __cap_c_impl(size)) _Pre_valid_impl_ _$STR_TYPE( \
+      _$preTStr)
+#define _Pre_opt_t_cap_c_(size)                                                                              \
+  _Pre1_impl_(__maybenull_impl_notref) _Pre2_impl_(__count_x_impl([0]), __cap_c_impl(size)) _Pre_valid_impl_ \
+  _$STR_TYPE(_$preTStr)
+#define _Pre_t_bytecap_c_(size)                                                                                \
+  _Pre1_impl_(__notnull_impl_notref) _Pre2_impl_(__count_x_impl([0]), __bytecap_c_impl(size)) _Pre_valid_impl_ \
+  _$STR_TYPE(_$preTStr)
+#define _Pre_opt_t_bytecap_c_(size)                                                                              \
+  _Pre1_impl_(__maybenull_impl_notref) _Pre2_impl_(__count_x_impl([0]), __bytecap_c_impl(size)) _Pre_valid_impl_ \
+  _$STR_TYPE(_$preTStr)
+#define _Pre_tz_cap_c_(size)                                                                                    \
+  _Pre1_impl_(__notnull_impl_notref) _Pre2_impl_(__zterm_impl, __cap_c_impl(size)) _Pre_valid_impl_ _$STR_TYPE( \
+      _$preTZStr)
+#define _Pre_opt_tz_cap_c_(size)                                                                                  \
+  _Pre1_impl_(__maybenull_impl_notref) _Pre2_impl_(__zterm_impl, __cap_c_impl(size)) _Pre_valid_impl_ _$STR_TYPE( \
+      _$preTZStr)
+#define _Pre_tz_bytecap_c_(size)                                                                                    \
+  _Pre1_impl_(__notnull_impl_notref) _Pre2_impl_(__zterm_impl, __bytecap_c_impl(size)) _Pre_valid_impl_ _$STR_TYPE( \
+      _$preTZStr)
+#define _Pre_opt_tz_bytecap_c_(size)                                                                                  \
+  _Pre1_impl_(__maybenull_impl_notref) _Pre2_impl_(__zterm_impl, __bytecap_c_impl(size)) _Pre_valid_impl_ _$STR_TYPE( \
+      _$preTZStr)
 
-#define _Pre_t_cap_x_(size)                                                               \
-  _Pre1_impl_(__notnull_impl_notref) _Pre2_impl_(__count_x_impl([0]), __cap_x_impl(size)) \
-      _Pre_valid_impl_ _$STR_TYPE(_$preTStr)
-#define _Pre_opt_t_cap_x_(size)                                                             \
-  _Pre1_impl_(__maybenull_impl_notref) _Pre2_impl_(__count_x_impl([0]), __cap_x_impl(size)) \
-      _Pre_valid_impl_ _$STR_TYPE(_$preTStr)
-#define _Pre_t_bytecap_x_(size)                                                               \
-  _Pre1_impl_(__notnull_impl_notref) _Pre2_impl_(__count_x_impl([0]), __bytecap_x_impl(size)) \
-      _Pre_valid_impl_ _$STR_TYPE(_$preTStr)
-#define _Pre_opt_t_bytecap_x_(size)                                                             \
-  _Pre1_impl_(__maybenull_impl_notref) _Pre2_impl_(__count_x_impl([0]), __bytecap_x_impl(size)) \
-      _Pre_valid_impl_ _$STR_TYPE(_$preTStr)
-#define _Pre_tz_cap_x_(size)                                                         \
-  _Pre1_impl_(__notnull_impl_notref) _Pre2_impl_(__zterm_impl, __cap_x_impl(_csize)) \
-      _Pre_valid_impl_ _$STR_TYPE(_$preTZStr)
-#define _Pre_opt_tz_cap_x_(size)                                                     \
-  _Pre1_impl_(__maybenull_impl_notref) _Pre2_impl_(__zterm_impl, __cap_x_impl(size)) \
-      _Pre_valid_impl_ _$STR_TYPE(_$preTZStr)
-#define _Pre_tz_bytecap_x_(size)                                                       \
-  _Pre1_impl_(__notnull_impl_notref) _Pre2_impl_(__zterm_impl, __bytecap_x_impl(size)) \
-      _Pre_valid_impl_ _$STR_TYPE(_$preTZStr)
-#define _Pre_opt_tz_bytecap_x_(size)                                                     \
-  _Pre1_impl_(__maybenull_impl_notref) _Pre2_impl_(__zterm_impl, __bytecap_x_impl(size)) \
-      _Pre_valid_impl_ _$STR_TYPE(_$preTZStr)
+#define _Pre_t_cap_x_(size)                                                                                            \
+  _Pre1_impl_(__notnull_impl_notref) _Pre2_impl_(__count_x_impl([0]), __cap_x_impl(size)) _Pre_valid_impl_ _$STR_TYPE( \
+      _$preTStr)
+#define _Pre_opt_t_cap_x_(size)                                                                              \
+  _Pre1_impl_(__maybenull_impl_notref) _Pre2_impl_(__count_x_impl([0]), __cap_x_impl(size)) _Pre_valid_impl_ \
+  _$STR_TYPE(_$preTStr)
+#define _Pre_t_bytecap_x_(size)                                                                                \
+  _Pre1_impl_(__notnull_impl_notref) _Pre2_impl_(__count_x_impl([0]), __bytecap_x_impl(size)) _Pre_valid_impl_ \
+  _$STR_TYPE(_$preTStr)
+#define _Pre_opt_t_bytecap_x_(size)                                                                              \
+  _Pre1_impl_(__maybenull_impl_notref) _Pre2_impl_(__count_x_impl([0]), __bytecap_x_impl(size)) _Pre_valid_impl_ \
+  _$STR_TYPE(_$preTStr)
+#define _Pre_tz_cap_x_(size)                                                                                      \
+  _Pre1_impl_(__notnull_impl_notref) _Pre2_impl_(__zterm_impl, __cap_x_impl(_csize)) _Pre_valid_impl_ _$STR_TYPE( \
+      _$preTZStr)
+#define _Pre_opt_tz_cap_x_(size)                                                                                  \
+  _Pre1_impl_(__maybenull_impl_notref) _Pre2_impl_(__zterm_impl, __cap_x_impl(size)) _Pre_valid_impl_ _$STR_TYPE( \
+      _$preTZStr)
+#define _Pre_tz_bytecap_x_(size)                                                                                    \
+  _Pre1_impl_(__notnull_impl_notref) _Pre2_impl_(__zterm_impl, __bytecap_x_impl(size)) _Pre_valid_impl_ _$STR_TYPE( \
+      _$preTZStr)
+#define _Pre_opt_tz_bytecap_x_(size)                                                                                  \
+  _Pre1_impl_(__maybenull_impl_notref) _Pre2_impl_(__zterm_impl, __bytecap_x_impl(size)) _Pre_valid_impl_ _$STR_TYPE( \
+      _$preTZStr)
 
 #define _Post_t_ _Post1_impl_(__count_x_impl([0])) _Post_valid_impl_ _$STR_TYPE(_$postTStr)
 #define _Post_tz_ _Post1_impl_(__zterm_impl) _Post_valid_impl_ _$STR_TYPE(_$postTZStr)
@@ -208,118 +208,130 @@
 #define _Deref_out_tz_ _Out_ _Deref_post_tz_
 #define _Deref_out_opt_tz_ _Out_ _Deref_post_opt_tz_
 
-#define _Deref_pre_t_                                                             \
-  _Deref_pre1_impl_(__notnull_impl_notref) _Deref_pre1_impl_(__count_x_impl([0])) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTStr)
-#define _Deref_pre_opt_t_                                                           \
-  _Deref_pre1_impl_(__maybenull_impl_notref) _Deref_pre1_impl_(__count_x_impl([0])) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTStr)
+#define _Deref_pre_t_                                                                                                \
+  _Deref_pre1_impl_(__notnull_impl_notref) _Deref_pre1_impl_(__count_x_impl([0])) _Pre_valid_impl_ _$DEREF_STR_TYPE( \
+      _$preTStr)
+#define _Deref_pre_opt_t_                                                                                              \
+  _Deref_pre1_impl_(__maybenull_impl_notref) _Deref_pre1_impl_(__count_x_impl([0])) _Pre_valid_impl_ _$DEREF_STR_TYPE( \
+      _$preTStr)
 #define _Deref_pre_tz_ \
   _Deref_pre1_impl_(__notnull_impl_notref) _Deref_pre1_impl_(__zterm_impl) _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTZStr)
-#define _Deref_pre_opt_tz_                                                   \
-  _Deref_pre1_impl_(__maybenull_impl_notref) _Deref_pre1_impl_(__zterm_impl) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTZStr)
+#define _Deref_pre_opt_tz_                                                                                      \
+  _Deref_pre1_impl_(__maybenull_impl_notref) _Deref_pre1_impl_(__zterm_impl) _Pre_valid_impl_ _$DEREF_STR_TYPE( \
+      _$preTZStr)
 
-#define _Deref_pre_t_cap_(size)                                                                     \
-  _Deref_pre1_impl_(__notnull_impl_notref) _Deref_pre2_impl_(__count_x_impl([0]), __cap_impl(size)) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTStr)
-#define _Deref_pre_opt_t_cap_(size)                                                                   \
-  _Deref_pre1_impl_(__maybenull_impl_notref) _Deref_pre2_impl_(__count_x_impl([0]), __cap_impl(size)) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTStr)
+#define _Deref_pre_t_cap_(size)                                                                                      \
+  _Deref_pre1_impl_(__notnull_impl_notref) _Deref_pre2_impl_(__count_x_impl([0]), __cap_impl(size)) _Pre_valid_impl_ \
+  _$DEREF_STR_TYPE(_$preTStr)
+#define _Deref_pre_opt_t_cap_(size)                                                                                    \
+  _Deref_pre1_impl_(__maybenull_impl_notref) _Deref_pre2_impl_(__count_x_impl([0]), __cap_impl(size)) _Pre_valid_impl_ \
+  _$DEREF_STR_TYPE(_$preTStr)
 #define _Deref_pre_t_bytecap_(size)                                                                     \
   _Deref_pre1_impl_(__notnull_impl_notref) _Deref_pre2_impl_(__count_x_impl([0]), __bytecap_impl(size)) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTStr)
+      _Pre_valid_impl_                                                                                  \
+      _$DEREF_STR_TYPE(_$preTStr)
 #define _Deref_pre_opt_t_bytecap_(size)                                                                   \
   _Deref_pre1_impl_(__maybenull_impl_notref) _Deref_pre2_impl_(__count_x_impl([0]), __bytecap_impl(size)) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTStr)
-#define _Deref_pre_tz_cap_(size)                                                             \
-  _Deref_pre1_impl_(__notnull_impl_notref) _Deref_pre2_impl_(__zterm_impl, __cap_impl(size)) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTZStr)
-#define _Deref_pre_opt_tz_cap_(size)                                                           \
-  _Deref_pre1_impl_(__maybenull_impl_notref) _Deref_pre2_impl_(__zterm_impl, __cap_impl(size)) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTZStr)
-#define _Deref_pre_tz_bytecap_(size)                                                             \
-  _Deref_pre1_impl_(__notnull_impl_notref) _Deref_pre2_impl_(__zterm_impl, __bytecap_impl(size)) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTZStr)
-#define _Deref_pre_opt_tz_bytecap_(size)                                                           \
-  _Deref_pre1_impl_(__maybenull_impl_notref) _Deref_pre2_impl_(__zterm_impl, __bytecap_impl(size)) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTZStr)
+      _Pre_valid_impl_                                                                                    \
+      _$DEREF_STR_TYPE(_$preTStr)
+#define _Deref_pre_tz_cap_(size)                                                                              \
+  _Deref_pre1_impl_(__notnull_impl_notref) _Deref_pre2_impl_(__zterm_impl, __cap_impl(size)) _Pre_valid_impl_ \
+  _$DEREF_STR_TYPE(_$preTZStr)
+#define _Deref_pre_opt_tz_cap_(size)                                                                            \
+  _Deref_pre1_impl_(__maybenull_impl_notref) _Deref_pre2_impl_(__zterm_impl, __cap_impl(size)) _Pre_valid_impl_ \
+  _$DEREF_STR_TYPE(_$preTZStr)
+#define _Deref_pre_tz_bytecap_(size)                                                                              \
+  _Deref_pre1_impl_(__notnull_impl_notref) _Deref_pre2_impl_(__zterm_impl, __bytecap_impl(size)) _Pre_valid_impl_ \
+  _$DEREF_STR_TYPE(_$preTZStr)
+#define _Deref_pre_opt_tz_bytecap_(size)                                                                            \
+  _Deref_pre1_impl_(__maybenull_impl_notref) _Deref_pre2_impl_(__zterm_impl, __bytecap_impl(size)) _Pre_valid_impl_ \
+  _$DEREF_STR_TYPE(_$preTZStr)
 
-#define _Deref_pre_t_cap_c_(size)                                                                     \
-  _Deref_pre1_impl_(__notnull_impl_notref) _Deref_pre2_impl_(__count_x_impl([0]), __cap_c_impl(size)) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTStr)
+#define _Deref_pre_t_cap_c_(size)                                                                                      \
+  _Deref_pre1_impl_(__notnull_impl_notref) _Deref_pre2_impl_(__count_x_impl([0]), __cap_c_impl(size)) _Pre_valid_impl_ \
+  _$DEREF_STR_TYPE(_$preTStr)
 #define _Deref_pre_opt_t_cap_c_(size)                                                                   \
   _Deref_pre1_impl_(__maybenull_impl_notref) _Deref_pre2_impl_(__count_x_impl([0]), __cap_c_impl(size)) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTStr)
+      _Pre_valid_impl_                                                                                  \
+      _$DEREF_STR_TYPE(_$preTStr)
 #define _Deref_pre_t_bytecap_c_(size)                                                                     \
   _Deref_pre1_impl_(__notnull_impl_notref) _Deref_pre2_impl_(__count_x_impl([0]), __bytecap_c_impl(size)) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTStr)
+      _Pre_valid_impl_                                                                                    \
+      _$DEREF_STR_TYPE(_$preTStr)
 #define _Deref_pre_opt_t_bytecap_c_(size)                                                                   \
   _Deref_pre1_impl_(__maybenull_impl_notref) _Deref_pre2_impl_(__count_x_impl([0]), __bytecap_c_impl(size)) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTStr)
-#define _Deref_pre_tz_cap_c_(size)                                                             \
-  _Deref_pre1_impl_(__notnull_impl_notref) _Deref_pre2_impl_(__zterm_impl, __cap_c_impl(size)) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTZStr)
-#define _Deref_pre_opt_tz_cap_c_(size)                                                           \
-  _Deref_pre1_impl_(__maybenull_impl_notref) _Deref_pre2_impl_(__zterm_impl, __cap_c_impl(size)) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTZStr)
-#define _Deref_pre_tz_bytecap_c_(size)                                                             \
-  _Deref_pre1_impl_(__notnull_impl_notref) _Deref_pre2_impl_(__zterm_impl, __bytecap_c_impl(size)) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTZStr)
-#define _Deref_pre_opt_tz_bytecap_c_(size)                                                           \
-  _Deref_pre1_impl_(__maybenull_impl_notref) _Deref_pre2_impl_(__zterm_impl, __bytecap_c_impl(size)) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTZStr)
+      _Pre_valid_impl_                                                                                      \
+      _$DEREF_STR_TYPE(_$preTStr)
+#define _Deref_pre_tz_cap_c_(size)                                                                              \
+  _Deref_pre1_impl_(__notnull_impl_notref) _Deref_pre2_impl_(__zterm_impl, __cap_c_impl(size)) _Pre_valid_impl_ \
+  _$DEREF_STR_TYPE(_$preTZStr)
+#define _Deref_pre_opt_tz_cap_c_(size)                                                                            \
+  _Deref_pre1_impl_(__maybenull_impl_notref) _Deref_pre2_impl_(__zterm_impl, __cap_c_impl(size)) _Pre_valid_impl_ \
+  _$DEREF_STR_TYPE(_$preTZStr)
+#define _Deref_pre_tz_bytecap_c_(size)                                                                              \
+  _Deref_pre1_impl_(__notnull_impl_notref) _Deref_pre2_impl_(__zterm_impl, __bytecap_c_impl(size)) _Pre_valid_impl_ \
+  _$DEREF_STR_TYPE(_$preTZStr)
+#define _Deref_pre_opt_tz_bytecap_c_(size)                                                                            \
+  _Deref_pre1_impl_(__maybenull_impl_notref) _Deref_pre2_impl_(__zterm_impl, __bytecap_c_impl(size)) _Pre_valid_impl_ \
+  _$DEREF_STR_TYPE(_$preTZStr)
 
-#define _Deref_pre_t_cap_x_(size)                                                                     \
-  _Deref_pre1_impl_(__notnull_impl_notref) _Deref_pre2_impl_(__count_x_impl([0]), __cap_x_impl(size)) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTStr)
+#define _Deref_pre_t_cap_x_(size)                                                                                      \
+  _Deref_pre1_impl_(__notnull_impl_notref) _Deref_pre2_impl_(__count_x_impl([0]), __cap_x_impl(size)) _Pre_valid_impl_ \
+  _$DEREF_STR_TYPE(_$preTStr)
 #define _Deref_pre_opt_t_cap_x_(size)                                                                   \
   _Deref_pre1_impl_(__maybenull_impl_notref) _Deref_pre2_impl_(__count_x_impl([0]), __cap_x_impl(size)) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTStr)
+      _Pre_valid_impl_                                                                                  \
+      _$DEREF_STR_TYPE(_$preTStr)
 #define _Deref_pre_t_bytecap_x_(size)                                                                     \
   _Deref_pre1_impl_(__notnull_impl_notref) _Deref_pre2_impl_(__count_x_impl([0]), __bytecap_x_impl(size)) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTStr)
+      _Pre_valid_impl_                                                                                    \
+      _$DEREF_STR_TYPE(_$preTStr)
 #define _Deref_pre_opt_t_bytecap_x_(size)                                                                   \
   _Deref_pre1_impl_(__maybenull_impl_notref) _Deref_pre2_impl_(__count_x_impl([0]), __bytecap_x_impl(size)) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTStr)
-#define _Deref_pre_tz_cap_x_(size)                                                             \
-  _Deref_pre1_impl_(__notnull_impl_notref) _Deref_pre2_impl_(__zterm_impl, __cap_x_impl(size)) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTZStr)
-#define _Deref_pre_opt_tz_cap_x_(size)                                                           \
-  _Deref_pre1_impl_(__maybenull_impl_notref) _Deref_pre2_impl_(__zterm_impl, __cap_x_impl(size)) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTZStr)
-#define _Deref_pre_tz_bytecap_x_(size)                                                             \
-  _Deref_pre1_impl_(__notnull_impl_notref) _Deref_pre2_impl_(__zterm_impl, __bytecap_x_impl(size)) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTZStr)
-#define _Deref_pre_opt_tz_bytecap_x_(size)                                                           \
-  _Deref_pre1_impl_(__maybenull_impl_notref) _Deref_pre2_impl_(__zterm_impl, __bytecap_x_impl(size)) \
-      _Pre_valid_impl_ _$DEREF_STR_TYPE(_$preTZStr)
+      _Pre_valid_impl_                                                                                      \
+      _$DEREF_STR_TYPE(_$preTStr)
+#define _Deref_pre_tz_cap_x_(size)                                                                              \
+  _Deref_pre1_impl_(__notnull_impl_notref) _Deref_pre2_impl_(__zterm_impl, __cap_x_impl(size)) _Pre_valid_impl_ \
+  _$DEREF_STR_TYPE(_$preTZStr)
+#define _Deref_pre_opt_tz_cap_x_(size)                                                                            \
+  _Deref_pre1_impl_(__maybenull_impl_notref) _Deref_pre2_impl_(__zterm_impl, __cap_x_impl(size)) _Pre_valid_impl_ \
+  _$DEREF_STR_TYPE(_$preTZStr)
+#define _Deref_pre_tz_bytecap_x_(size)                                                                              \
+  _Deref_pre1_impl_(__notnull_impl_notref) _Deref_pre2_impl_(__zterm_impl, __bytecap_x_impl(size)) _Pre_valid_impl_ \
+  _$DEREF_STR_TYPE(_$preTZStr)
+#define _Deref_pre_opt_tz_bytecap_x_(size)                                                                            \
+  _Deref_pre1_impl_(__maybenull_impl_notref) _Deref_pre2_impl_(__zterm_impl, __bytecap_x_impl(size)) _Pre_valid_impl_ \
+  _$DEREF_STR_TYPE(_$preTZStr)
 
-#define _Deref_post_t_                                                              \
-  _Deref_post1_impl_(__notnull_impl_notref) _Deref_post1_impl_(__count_x_impl([0])) \
-      _Post_valid_impl_ _$DEREF_STR_TYPE(_$postTStr)
-#define _Deref_post_opt_t_                                                            \
-  _Deref_post1_impl_(__maybenull_impl_notref) _Deref_post1_impl_(__count_x_impl([0])) \
-      _Post_valid_impl_ _$DEREF_STR_TYPE(_$postTStr)
-#define _Deref_post_tz_                                                      \
-  _Deref_post1_impl_(__notnull_impl_notref) _Deref_post1_impl_(__zterm_impl) \
-      _Post_valid_impl_ _$DEREF_STR_TYPE(_$postTZStr)
-#define _Deref_post_opt_tz_                                                    \
-  _Deref_post1_impl_(__maybenull_impl_notref) _Deref_post1_impl_(__zterm_impl) \
-      _Post_valid_impl_ _$DEREF_STR_TYPE(_$postTZStr)
+#define _Deref_post_t_                                                                                \
+  _Deref_post1_impl_(__notnull_impl_notref) _Deref_post1_impl_(__count_x_impl([0])) _Post_valid_impl_ \
+  _$DEREF_STR_TYPE(_$postTStr)
+#define _Deref_post_opt_t_                                                                              \
+  _Deref_post1_impl_(__maybenull_impl_notref) _Deref_post1_impl_(__count_x_impl([0])) _Post_valid_impl_ \
+  _$DEREF_STR_TYPE(_$postTStr)
+#define _Deref_post_tz_                                                                                          \
+  _Deref_post1_impl_(__notnull_impl_notref) _Deref_post1_impl_(__zterm_impl) _Post_valid_impl_ _$DEREF_STR_TYPE( \
+      _$postTZStr)
+#define _Deref_post_opt_tz_                                                                                        \
+  _Deref_post1_impl_(__maybenull_impl_notref) _Deref_post1_impl_(__zterm_impl) _Post_valid_impl_ _$DEREF_STR_TYPE( \
+      _$postTZStr)
 
 #define _Deref_post_t_cap_(size)                                                                      \
   _Deref_post1_impl_(__notnull_impl_notref) _Deref_post2_impl_(__count_x_impl([0]), __cap_impl(size)) \
-      _Post_valid_impl_ _$DEREF_STR_TYPE(_$postTStr)
+      _Post_valid_impl_                                                                               \
+      _$DEREF_STR_TYPE(_$postTStr)
 #define _Deref_post_opt_t_cap_(size)                                                                    \
   _Deref_post1_impl_(__maybenull_impl_notref) _Deref_post2_impl_(__count_x_impl([0]), __cap_impl(size)) \
-      _Post_valid_impl_ _$DEREF_STR_TYPE(_$postTStr)
+      _Post_valid_impl_                                                                                 \
+      _$DEREF_STR_TYPE(_$postTStr)
 #define _Deref_post_t_bytecap_(size)                                                                      \
   _Deref_post1_impl_(__notnull_impl_notref) _Deref_post2_impl_(__count_x_impl([0]), __bytecap_impl(size)) \
-      _Post_valid_impl_ _$DEREF_STR_TYPE(_$postTStr)
+      _Post_valid_impl_                                                                                   \
+      _$DEREF_STR_TYPE(_$postTStr)
 #define _Deref_post_opt_t_bytecap_(size)                                                                    \
   _Deref_post1_impl_(__maybenull_impl_notref) _Deref_post2_impl_(__count_x_impl([0]), __bytecap_impl(size)) \
-      _Post_valid_impl_ _$DEREF_STR_TYPE(_$postTStr)
+      _Post_valid_impl_                                                                                     \
+      _$DEREF_STR_TYPE(_$postTStr)
 #define _Deref_post_tz_cap_(size)                       _Deref_post1_impl_(__notnull_impl_notref)   _Deref_post2_impl_(__zterm_impl),__cap_impl(size))     _Post_valid_impl_ _$DEREF_STR_TYPE(_$postTZStr)
 #define _Deref_post_opt_tz_cap_(size)                   _Deref_post1_impl_(__maybenull_impl_notref) _Deref_post2_impl_(__zterm_impl),__cap_impl(size))     _Post_valid_impl_ _$DEREF_STR_TYPE(_$postTZStr)
 #define _Deref_post_tz_bytecap_(size)                   _Deref_post1_impl_(__notnull_impl_notref)   _Deref_post2_impl_(__zterm_impl),__bytecap_impl(size)) _Post_valid_impl_ _$DEREF_STR_TYPE(_$postTZStr)
@@ -327,16 +339,20 @@
 
 #define _Deref_post_t_cap_c_(size)                                                                      \
   _Deref_post1_impl_(__notnull_impl_notref) _Deref_post2_impl_(__count_x_impl([0]), __cap_c_impl(size)) \
-      _Post_valid_impl_ _$DEREF_STR_TYPE(_$postTStr)
+      _Post_valid_impl_                                                                                 \
+      _$DEREF_STR_TYPE(_$postTStr)
 #define _Deref_post_opt_t_cap_c_(size)                                                                    \
   _Deref_post1_impl_(__maybenull_impl_notref) _Deref_post2_impl_(__count_x_impl([0]), __cap_c_impl(size)) \
-      _Post_valid_impl_ _$DEREF_STR_TYPE(_$postTStr)
+      _Post_valid_impl_                                                                                   \
+      _$DEREF_STR_TYPE(_$postTStr)
 #define _Deref_post_t_bytecap_c_(size)                                                                      \
   _Deref_post1_impl_(__notnull_impl_notref) _Deref_post2_impl_(__count_x_impl([0]), __bytecap_c_impl(size)) \
-      _Post_valid_impl_ _$DEREF_STR_TYPE(_$postTStr)
+      _Post_valid_impl_                                                                                     \
+      _$DEREF_STR_TYPE(_$postTStr)
 #define _Deref_post_opt_t_bytecap_c_(size)                                                                    \
   _Deref_post1_impl_(__maybenull_impl_notref) _Deref_post2_impl_(__count_x_impl([0]), __bytecap_c_impl(size)) \
-      _Post_valid_impl_ _$DEREF_STR_TYPE(_$postTStr)
+      _Post_valid_impl_                                                                                       \
+      _$DEREF_STR_TYPE(_$postTStr)
 #define _Deref_post_tz_cap_c_(size)                     _Deref_post1_impl_(__notnull_impl_notref)   _Deref_post2_impl_(__zterm_impl),__cap_c_impl(size))     _Post_valid_impl_ _$DEREF_STR_TYPE(_$postTZStr)
 #define _Deref_post_opt_tz_cap_c_(size)                 _Deref_post1_impl_(__maybenull_impl_notref) _Deref_post2_impl_(__zterm_impl),__cap_c_impl(size))     _Post_valid_impl_ _$DEREF_STR_TYPE(_$postTZStr)
 #define _Deref_post_tz_bytecap_c_(size)                 _Deref_post1_impl_(__notnull_impl_notref)   _Deref_post2_impl_(__zterm_impl),__bytecap_c_impl(size)) _Post_valid_impl_ _$DEREF_STR_TYPE(_$postTZStr)
@@ -344,16 +360,20 @@
 
 #define _Deref_post_t_cap_x_(size)                                                                      \
   _Deref_post1_impl_(__notnull_impl_notref) _Deref_post2_impl_(__count_x_impl([0]), __cap_x_impl(size)) \
-      _Post_valid_impl_ _$DEREF_STR_TYPE(_$postTStr)
+      _Post_valid_impl_                                                                                 \
+      _$DEREF_STR_TYPE(_$postTStr)
 #define _Deref_post_opt_t_cap_x_(size)                                                                    \
   _Deref_post1_impl_(__maybenull_impl_notref) _Deref_post2_impl_(__count_x_impl([0]), __cap_x_impl(size)) \
-      _Post_valid_impl_ _$DEREF_STR_TYPE(_$postTStr)
+      _Post_valid_impl_                                                                                   \
+      _$DEREF_STR_TYPE(_$postTStr)
 #define _Deref_post_t_bytecap_x_(size)                                                                      \
   _Deref_post1_impl_(__notnull_impl_notref) _Deref_post2_impl_(__count_x_impl([0]), __bytecap_x_impl(size)) \
-      _Post_valid_impl_ _$DEREF_STR_TYPE(_$postTStr)
+      _Post_valid_impl_                                                                                     \
+      _$DEREF_STR_TYPE(_$postTStr)
 #define _Deref_post_opt_t_bytecap_x_(size)                                                                    \
   _Deref_post1_impl_(__maybenull_impl_notref) _Deref_post2_impl_(__count_x_impl([0]), __bytecap_x_impl(size)) \
-      _Post_valid_impl_ _$DEREF_STR_TYPE(_$postTStr)
+      _Post_valid_impl_                                                                                       \
+      _$DEREF_STR_TYPE(_$postTStr)
 #define _Deref_post_tz_cap_x_(size)                     _Deref_post1_impl_(__notnull_impl_notref)   _Deref_post2_impl_(__zterm_impl),__cap_x_impl(size))     _Post_valid_impl_ _$DEREF_STR_TYPE(_$postTZStr)
 #define _Deref_post_opt_tz_cap_x_(size)                 _Deref_post1_impl_(__maybenull_impl_notref) _Deref_post2_impl_(__zterm_impl),__cap_x_impl(size))     _Post_valid_impl_ _$DEREF_STR_TYPE(_$postTZStr)
 #define _Deref_post_tz_bytecap_x_(size)                 _Deref_post1_impl_(__notnull_impl_notref)   _Deref_post2_impl_(__zterm_impl),__bytecap_x_impl(size)) _Post_valid_impl_ _$DEREF_STR_TYPE(_$postTZStr)

--- a/libs/object/tests/fixedSwarmTest.cpp
+++ b/libs/object/tests/fixedSwarmTest.cpp
@@ -10,8 +10,8 @@ Unit tests for classes in the ObjectSwarm.h
 #include <object/refCountedObject.h>
 #include <motifCpp/testCheck.h>
 
-//#define TEST_BAD_INHERITANCE1 // Uncomment to confirm VEC, but observe a memory leak. We cannot safely destroy this
-// class.
+// #define TEST_BAD_INHERITANCE1 // Uncomment to confirm VEC, but observe a memory leak. We cannot safely destroy this
+//  class.
 
 MSO_STRUCT_GUID(IFixedSwarmSample1, "AA2EB60A-06DD-486F-AC9B-DBF1DDE21408")
 struct DECLSPEC_NOVTABLE IFixedSwarmSample1 : IUnknown

--- a/libs/object/tests/refCountedObjectTest.cpp
+++ b/libs/object/tests/refCountedObjectTest.cpp
@@ -6,9 +6,9 @@
 #include <eventWaitHandle/eventWaitHandle.h>
 #include <motifCpp/testCheck.h>
 
-//#define TEST_BAD_INHERITANCE1 // Uncomment to see compilation error
-//#define TEST_BAD_INHERITANCE2 // Uncomment to confirm VEC, but observe a memory leak. We cannot safely destroy this
-// class.
+// #define TEST_BAD_INHERITANCE1 // Uncomment to see compilation error
+// #define TEST_BAD_INHERITANCE2 // Uncomment to confirm VEC, but observe a memory leak. We cannot safely destroy this
+//  class.
 
 struct DECLSPEC_NOVTABLE IRefBaseSample1 : public Mso::IRefCounted
 {

--- a/libs/object/tests/swarmTest.cpp
+++ b/libs/object/tests/swarmTest.cpp
@@ -11,8 +11,8 @@ Unit tests for classes in the ObjectSwarm.h
 #include <motifCpp/testCheck.h>
 #include <comUtil/qiCast.h>
 
-//#define TEST_BAD_INHERITANCE1 // Uncomment to confirm VEC, but observe a memory leak. We cannot safely destroy this
-// class.
+// #define TEST_BAD_INHERITANCE1 // Uncomment to confirm VEC, but observe a memory leak. We cannot safely destroy this
+//  class.
 
 MSO_STRUCT_GUID(ISwarmSample1, "962D2470-7452-43AB-9F74-63545A3E8A58")
 struct DECLSPEC_NOVTABLE ISwarmSample1 : public IUnknown

--- a/libs/object/tests/unknownObjectTest.cpp
+++ b/libs/object/tests/unknownObjectTest.cpp
@@ -10,9 +10,9 @@
 #include <motifCpp/testCheck.h>
 #include "testAllocators.h"
 
-//#define TEST_BAD_INHERITANCE1 // Uncomment to see compilation error
-//#define TEST_BAD_INHERITANCE2 // Uncomment to confirm VEC, but observe a memory leak. We cannot safely destroy this
-// class.
+// #define TEST_BAD_INHERITANCE1 // Uncomment to see compilation error
+// #define TEST_BAD_INHERITANCE2 // Uncomment to confirm VEC, but observe a memory leak. We cannot safely destroy this
+//  class.
 
 MSO_STRUCT_GUID(IBaseSample1, "16872411-FA64-436C-92F4-22FE6B536FC8")
 struct DECLSPEC_NOVTABLE IBaseSample1 : public IUnknown

--- a/libs/smartPtr/include/smartPtr/cntPtr.h
+++ b/libs/smartPtr/include/smartPtr/cntPtr.h
@@ -160,14 +160,14 @@ struct CntPtrRef
   template <typename U>
   friend struct CntPtr;
 
-  operator CntPtr<T> *() const noexcept;
+  operator CntPtr<T>*() const noexcept;
   operator void*() const noexcept;
-  operator T* *() const noexcept;
-  operator void* *() const noexcept;
-  operator const void* *() const noexcept;
+  operator T**() const noexcept;
+  operator void**() const noexcept;
+  operator const void**() const noexcept;
 
   template <typename TBase, EnableIfIsBaseOf<TBase, T> = 0>
-  explicit operator TBase* *() const noexcept;
+  explicit operator TBase**() const noexcept;
 
   T*& operator*() noexcept;
   T** ClearAndGetAddressOf() noexcept;
@@ -572,7 +572,7 @@ inline CntPtrRef<T>::CntPtrRef(_In_ CntPtr<T>* pCntPtr) noexcept : m_pCntPtr{pCn
 }
 
 template <typename T>
-inline CntPtrRef<T>::operator CntPtr<T> *() const noexcept
+inline CntPtrRef<T>::operator CntPtr<T>*() const noexcept
 {
   return const_cast<CntPtrRef*>(this)->m_pCntPtr;
 }
@@ -584,26 +584,26 @@ inline CntPtrRef<T>::operator void*() const noexcept
 }
 
 template <typename T>
-inline CntPtrRef<T>::operator T* *() const noexcept
+inline CntPtrRef<T>::operator T**() const noexcept
 {
   return const_cast<CntPtrRef*>(this)->m_pCntPtr->GetAddressOf();
 }
 
 template <typename T>
-inline CntPtrRef<T>::operator void* *() const noexcept
+inline CntPtrRef<T>::operator void**() const noexcept
 {
   return reinterpret_cast<void**>(const_cast<CntPtrRef*>(this)->m_pCntPtr->GetAddressOf());
 }
 
 template <typename T>
-inline CntPtrRef<T>::operator const void* *() const noexcept
+inline CntPtrRef<T>::operator const void**() const noexcept
 {
   return (const void**)(const_cast<CntPtrRef*>(this)->m_pCntPtr->GetAddressOf());
 }
 
 template <typename T>
 template <typename TBase, EnableIfIsBaseOf<TBase, T>>
-inline CntPtrRef<T>::operator TBase* *() const noexcept
+inline CntPtrRef<T>::operator TBase**() const noexcept
 {
   return (TBase**)const_cast<CntPtrRef*>(this)->m_pCntPtr->GetAddressOf();
 }

--- a/libs/smartPtr/include/smartPtr/smartPointerBase.h
+++ b/libs/smartPtr/include/smartPtr/smartPointerBase.h
@@ -379,12 +379,14 @@ bool operator!=(std::nullptr_t, const THolder<T1, THelper1, TEmptyTraits1>& a) n
 /**
   Helper to add RVALUE methods to derived THolder classes
 */
-#define IMPLEMENT_THOLDER_RVALUE_REFS_(T, TBase)                       \
-  T(_Inout_ T&& rFrom) noexcept : TBase(std::forward<TBase>(rFrom)) {} \
-  T& operator=(_Inout_ T&& rFrom) noexcept                             \
-  {                                                                    \
-    this->TransferFrom(rFrom);                                         \
-    return *this;                                                      \
+#define IMPLEMENT_THOLDER_RVALUE_REFS_(T, TBase)                    \
+  T(_Inout_ T&& rFrom) noexcept : TBase(std::forward<TBase>(rFrom)) \
+  {                                                                 \
+  }                                                                 \
+  T& operator=(_Inout_ T&& rFrom) noexcept                          \
+  {                                                                 \
+    this->TransferFrom(rFrom);                                      \
+    return *this;                                                   \
   }
 #define IMPLEMENT_THOLDER_RVALUE_REFS(T) IMPLEMENT_THOLDER_RVALUE_REFS_(T, Super)
 

--- a/libs/tagUtils/include/tagUtils/tagUtils.h
+++ b/libs/tagUtils/include/tagUtils/tagUtils.h
@@ -340,7 +340,7 @@ public:
   /**
   @return a pointer to a null-terminated character buffer
   */
-  _Ret_z_ operator T const *() const noexcept
+  _Ret_z_ operator T const*() const noexcept
   {
     return this->c_str();
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "devDependencies": {
     "beachball": "2.21.0",
-    "clang-format": "1.6.0",
+    "clang-format": "1.8.0",
     "husky": "7.0.4"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -118,10 +118,10 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
-async@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
-  integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
+async@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
+  integrity sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
 
 at-least-node@^1.0.0:
   version "1.0.0"
@@ -232,12 +232,12 @@ chalk@^2.0.0:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-clang-format@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/clang-format/-/clang-format-1.6.0.tgz#48fac4387712aeeae0f47b5d72f639f3fd95f4b6"
-  integrity sha512-W3/L7fWkA8DoLkz9UGjrRnNi+J5a5TuS2HDLqk6WsicpOzb66MBu4eY/EcXhicHriVnAXWQVyk5/VeHWY6w4ow==
+clang-format@1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/clang-format/-/clang-format-1.8.0.tgz#7779df1c5ce1bc8aac1b0b02b4e479191ef21d46"
+  integrity sha512-pK8gzfu55/lHzIpQ1givIbWfn3eXnU7SfxqIwVgnn5jEM6j4ZJYjpFqFs4iSBPNedzRMmfjYjuQhu657WAXHXw==
   dependencies:
-    async "^1.5.2"
+    async "^3.2.3"
     glob "^7.0.0"
     resolve "^1.1.6"
 


### PR DESCRIPTION
This change bumps clang-format from 1.6.0 to 1.8.0.
The motivation for this bump is to update the async package which has a 'high' security issue [CVE-2021-43138](https://github.com/advisories/GHSA-fwr7-v2mv-hh25)

The other changes are done by running `yarn format` and are due to updated clang-format rules.